### PR TITLE
Fix single step macros

### DIFF
--- a/src/combat.ts
+++ b/src/combat.ts
@@ -166,7 +166,7 @@ export class Macro {
     );
     this.components = [
       ...this.components,
-      ...nextStepsStrings.filter((s) => s.length > 0).map((s)=>s+";"),
+      ...nextStepsStrings.filter((s) => s.length > 0).map((s) => s + ";"),
     ];
     return this;
   }

--- a/src/combat.ts
+++ b/src/combat.ts
@@ -164,10 +164,9 @@ export class Macro {
     const nextStepsStrings = ([] as string[]).concat(
       ...nextSteps.map((x) => (x instanceof Macro ? x.components : [x]))
     );
-    this.components = [
-      ...this.components,
-      ...nextStepsStrings.filter((s) => s.length > 0).map((s) => s + ";"),
-    ];
+    this.components.push(
+      ...nextStepsStrings.filter((s) => s.length > 0).map((s) => s + ";")
+    );
     return this;
   }
 

--- a/src/combat.ts
+++ b/src/combat.ts
@@ -120,7 +120,7 @@ export class Macro {
    * Convert macro to string.
    */
   toString(): string {
-    return this.components.join(";");
+    return this.components.join();
   }
 
   /**
@@ -166,7 +166,7 @@ export class Macro {
     );
     this.components = [
       ...this.components,
-      ...nextStepsStrings.filter((s) => s.length > 0),
+      ...nextStepsStrings.filter((s) => s.length > 0).map((s)=>s+";"),
     ];
     return this;
   }

--- a/src/combat.ts
+++ b/src/combat.ts
@@ -120,7 +120,7 @@ export class Macro {
    * Convert macro to string.
    */
   toString(): string {
-    return this.components.join();
+    return this.components.join("");
   }
 
   /**
@@ -165,7 +165,7 @@ export class Macro {
       ...nextSteps.map((x) => (x instanceof Macro ? x.components : [x]))
     );
     this.components.push(
-      ...nextStepsStrings.filter((s) => s.length > 0).map((s) => s + ";")
+      ...nextStepsStrings.filter((s) => s.length > 0).map((s) => s.endsWith(";") ? s : s + ";")
     );
     return this;
   }

--- a/src/combat.ts
+++ b/src/combat.ts
@@ -120,7 +120,7 @@ export class Macro {
    * Convert macro to string.
    */
   toString(): string {
-    return this.components.join("");
+    return (this.components.join(";") + ";").replace(/;;+/g, ";");
   }
 
   /**
@@ -164,11 +164,7 @@ export class Macro {
     const nextStepsStrings = ([] as string[]).concat(
       ...nextSteps.map((x) => (x instanceof Macro ? x.components : [x]))
     );
-    this.components.push(
-      ...nextStepsStrings
-        .filter((s) => s.length > 0)
-        .map((s) => (s.endsWith(";") ? s : s + ";"))
-    );
+    this.components.push(...nextStepsStrings.filter((s) => s.length > 0));
     return this;
   }
 

--- a/src/combat.ts
+++ b/src/combat.ts
@@ -165,7 +165,9 @@ export class Macro {
       ...nextSteps.map((x) => (x instanceof Macro ? x.components : [x]))
     );
     this.components.push(
-      ...nextStepsStrings.filter((s) => s.length > 0).map((s) => s.endsWith(";") ? s : s + ";")
+      ...nextStepsStrings
+        .filter((s) => s.length > 0)
+        .map((s) => (s.endsWith(";") ? s : s + ";"))
     );
     return this;
   }


### PR DESCRIPTION
Single step macros are generated incorrectly. Fix by always appending a semicolon to a component and don't join with a semicolon.

Example error of what happens without a semicolon:
```
run_combat("skill 1234");

Macro override "skill 1234" returned void.
Round 1: Player executes a macro!
KoLmafia thinks it is round 2 but KoL thinks it is round 1
You're on your own, partner. (Macro Aborted: 37 instructions (In a row?!) executed without any actions being taken.).
```