### PR TITLE
Adjust ascension detection to work in compact character pane

### DIFF
--- a/src/ascend.ts
+++ b/src/ascend.ts
@@ -218,11 +218,7 @@ function toMoonId(moon: MoonSign, playerClass: Class): number {
 }
 
 function isInValhalla(): boolean {
-  const charPaneText = visitUrl("charpane.php");
-  return (
-    containsText(charPaneText, "Lvl. <img src=") ||
-    containsText(charPaneText, "Level <img src=")
-  );
+  return containsText(visitUrl("charpane.php"), "Karma:");
 }
 
 /**

--- a/src/ascend.ts
+++ b/src/ascend.ts
@@ -271,11 +271,13 @@ export function ascend(
     throw new AscendError(illegalSkill);
   }
 
-  if (!containsText(visitUrl("charpane.php"), "Astral Spirit")) {
+  if (!containsText(visitUrl("charpane.php"), "Lvl. <img src=")) {
     visitUrl("ascend.php?action=ascend&confirm=on&confirm2=on");
   }
-  if (!containsText(visitUrl("charpane.php"), "Astral Spirit")) {
-    throw new AscendError();
+  if (!containsText(visitUrl("charpane.php"), "Lvl. <img src=")) {
+    throw new AscendError(
+      "Couldn't determine whether ascension completed successfully"
+    );
   }
 
   visitUrl("afterlife.php?action=pearlygates");

--- a/src/ascend.ts
+++ b/src/ascend.ts
@@ -279,9 +279,7 @@ export function ascend(
     visitUrl("ascend.php?action=ascend&confirm=on&confirm2=on");
   }
   if (!isInValhalla()) {
-    throw new AscendError(
-      "Couldn't determine whether ascension completed successfully"
-    );
+    throw new AscendError();
   }
 
   visitUrl("afterlife.php?action=pearlygates");

--- a/src/ascend.ts
+++ b/src/ascend.ts
@@ -217,6 +217,14 @@ function toMoonId(moon: MoonSign, playerClass: Class): number {
   }
 }
 
+function isInValhalla(): boolean {
+  const charPaneText = visitUrl("charpane.php");
+  return (
+    containsText(charPaneText, "Lvl. <img src=") ||
+    containsText(charPaneText, "Level <img src=")
+  );
+}
+
 /**
  * Hops the gash, perming no skills
  * @param path path of choice, as a Path object--these exist as properties of Paths
@@ -271,10 +279,10 @@ export function ascend(
     throw new AscendError(illegalSkill);
   }
 
-  if (!containsText(visitUrl("charpane.php"), "Lvl. <img src=")) {
+  if (!isInValhalla()) {
     visitUrl("ascend.php?action=ascend&confirm=on&confirm2=on");
   }
-  if (!containsText(visitUrl("charpane.php"), "Lvl. <img src=")) {
+  if (!isInValhalla()) {
     throw new AscendError(
       "Couldn't determine whether ascension completed successfully"
     );


### PR DESCRIPTION
The existing ascension detection code looks for "Astral Spirit" in the character pane, but when using KoL's built in "compact character pane" option, the class name is never shown:

<img width="147" alt="Screen Shot 2022-11-05 at 12 05 39 PM" src="https://user-images.githubusercontent.com/481668/200129117-dc7e5a67-3e4f-4d82-b1b7-9ea9dc7323b6.png">

Instead, can we use this detection that checks whether Lvl. is followed by an image? I avoided coding in the actual image name in case KoL ever changes that for some reason.

Manually tested the ASH versions of these directly in the mafia CLI:
```
> ash contains_text(visit_url("charpane.php"), "Karma:")

Returned: true
```

Also added a more specific error string so it's clear what failure is happening if users encounter this in the future.