### PR TITLE
Fix ascension detection (again)

### DIFF
--- a/src/ascend.ts
+++ b/src/ascend.ts
@@ -1,7 +1,6 @@
 import {
   Skill,
   Class,
-  containsText,
   eudoraItem,
   getCampground,
   getWorkshed,
@@ -218,7 +217,14 @@ function toMoonId(moon: MoonSign, playerClass: Class): number {
 }
 
 function isInValhalla(): boolean {
-  return containsText(visitUrl("charpane.php"), "Karma:");
+  const charPaneText = visitUrl("charpane.php");
+  // Match the infinity images (inf_small.gif, inf_large.gif)
+  // At time of writing, the full img tag used is:
+  // <img src="https://d2uyhvukfffg5a.cloudfront.net/otherimages/inf_small.gif">
+  const matches = charPaneText.match(
+    /<img src="[^"]*\/otherimages\/inf_\w+\.gif">/
+  );
+  return matches !== null;
 }
 
 /**


### PR DESCRIPTION
The previous iteration fixed it for compact character pane, but broke it for full character pane. This version looks for the infinity img tag used while in Valhalla.

I've manually tested this in the compact character pane but have not yet verified in full character pane – you can't change the option while in Valhalla. I can manually test tomorrow or someone else can confirm this works for full too.