### PR TITLE
Only mode items when a configuration is given

### DIFF
--- a/src/maximize.ts
+++ b/src/maximize.ts
@@ -156,7 +156,7 @@ export function getCurrentModes(): Modes {
 
 export function applyModes(modes: Modes) {
   for (const command of modeableCommands) {
-    if (haveEquipped(modeableItems[command])) {
+    if (haveEquipped(modeableItems[command]) && modes[command] !== undefined) {
       if (modeableState[command]() !== modes[command]) {
         cliExecute(command + " " + modes[command]);
       }


### PR DESCRIPTION
The applyModes function accepts a `Partial<{ [x in Mode]: string }>` parameter, but if you don't provide a configuration to an item you have equipped an error is printed to the console. For example:
```
  equip($item`backup camera`);
  applyModes({});
```

produces:
```
Putting on backup camera...
Equipment changed.
The command undefined was not recognised
```

This pull request changes it so that equipped items are completely ignored by applyModes to no mode for them is provided.