### PR TITLE
Don't log when equipping same outfit.

### DIFF
--- a/src/maximize.ts
+++ b/src/maximize.ts
@@ -558,6 +558,7 @@ export function maximizeCached(
 
   const cacheEntry = checkCache(cacheKey, fullOptions);
   if (cacheEntry && !forceUpdate) {
+    if (verifyCached(cacheEntry)) return true;
     logger.info("Equipment found in maximize cache, equipping...");
     applyCached(cacheEntry, fullOptions);
     if (verifyCached(cacheEntry)) {


### PR DESCRIPTION
I'm trying to do some log spam reduction, so this just doesn't have libram logging print anymore when reequipping the same cached outfit.