### PR TITLE
default `flat` to infinite depth

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -328,7 +328,7 @@ export function makeByXFunction<T extends string>(
  * Flattens an array. Basically replacing Array.prototype.flat for which Rhino doesn't yet have an implementation
  *
  * @param arr Array to flatten
- * @param depth Level to flatten
+ * @param depth Number of layers to flatten by; Infinity for a fully flat array
  * @returns Flattened array
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -334,7 +334,7 @@ export function makeByXFunction<T extends string>(
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function flat<A extends any[], D extends number = 1>(
   arr: A,
-  depth = 1
+  depth = Infinity
 ): FlatArray<A, D>[] {
   let flatArray: FlatArray<A, D>[] = [];
   for (const item of arr) {


### PR DESCRIPTION
Right now, `depth = 1` flattens _by_ one layer, instead of _to_ one layer. Default behavior should flatten _to_ one layer, which can only be consistently achieved by using `Infinity`.