### PR TITLE
create MacroPredicate and CompoundMacroPredicate types

### DIFF
--- a/src/combat.ts
+++ b/src/combat.ts
@@ -13,6 +13,7 @@ import {
   setAutoAttack,
   Skill,
   Stat,
+  StatType,
   toInt,
   urlEncode,
   visitUrl,
@@ -97,6 +98,47 @@ function itemOrItemsBallsMacroPredicate(
     return `hascombatitem ${itemOrItems}`;
   }
 }
+
+type RawNumberMacroPredicate =
+  | "times"
+  | "hpbelow"
+  | "hppercentbelow"
+  | "mpbelow"
+  | "mppercentbelow"
+  | "didcritical"
+  | "beenhit"
+  | "missed"
+  | "familiarattacked"
+  | "gotjump"
+  | "pastround"
+  | "monsterhpabove"
+  | "monsterhpbelow"
+  | "snarfblat";
+type RawStringMacroPredicate = "match" | "monstername" | "happymediumglow";
+type RawNumberOrStringMacroPredicate =
+  | "haseffect"
+  | "hascombatitem"
+  | "monsterid"
+  | "hasskill";
+type NudeMacroPredicate =
+  | "sealclubber"
+  | "turtletamer"
+  | "pastamancer"
+  | "sauceror"
+  | "discobandit"
+  | "accordionthief"
+  | `${Lowercase<StatType>}class`;
+export type MacroPredicate =
+  | `${RawNumberMacroPredicate} ${number}`
+  | `${RawStringMacroPredicate} ${string}`
+  | `${RawNumberOrStringMacroPredicate} ${number | string}`
+  | NudeMacroPredicate;
+
+export type CompoundMacroPredicate =
+  | MacroPredicate
+  | `${CompoundMacroPredicate} || ${CompoundMacroPredicate}`
+  | `${CompoundMacroPredicate} && ${CompoundMacroPredicate}`
+  | `(${CompoundMacroPredicate})`;
 
 type PreBALLSPredicate =
   | string


### PR DESCRIPTION
TypeScript does not (and plausibly never will) support recursive template literal types, and so CompoundMacroPredicate is but a dream. Alas!