### PR TITLE
print "update kolmafia" message when a Type.get fails

### DIFF
--- a/src/template-string.ts
+++ b/src/template-string.ts
@@ -1,4 +1,5 @@
 import {
+  abort,
   Bounty,
   Class,
   Coinmaster,
@@ -11,6 +12,7 @@ import {
   Monster,
   Path,
   Phylum,
+  print,
   Servant,
   Skill,
   Slot,
@@ -38,7 +40,12 @@ const createSingleConstant = <T extends MafiaClass>(
   ) => {
     const input = concatTemplateString(literals, ...placeholders);
     type I = InstanceType<typeof Type>;
-    return Type.get<I>(input);
+    try {
+      return Type.get<I>(input);
+    } catch (error) {
+      print(`${error}; you should probably update KoLmafia!`, "red");
+    }
+    abort();
   };
   tagFunction.none = Type.none as T;
   return tagFunction;
@@ -55,7 +62,12 @@ const createPluralConstant =
       return Type.all<I>();
     }
 
-    return Type.get<I>(splitByCommasWithEscapes(input));
+    try {
+      return Type.get<I>(splitByCommasWithEscapes(input));
+    } catch (error) {
+      print(`${error}; you should probably update KoLmafia!`, "red");
+    }
+    abort();
   };
 
 /**

--- a/src/template-string.ts
+++ b/src/template-string.ts
@@ -65,7 +65,17 @@ const createPluralConstant =
     try {
       return Type.get<I>(splitByCommasWithEscapes(input));
     } catch (error) {
-      print(`${error}; you should probably update KoLmafia!`, "red");
+      const message = `${error}`;
+      const match = message.match(
+        RegExp(`Bad ${Type.name.toString()} value: (.*)`, "i")
+      );
+      if (match) {
+        print(
+          `${match[0]}; if you're certain that ${Type} exists and is spelled correctly, please update KoLMafia`
+        );
+      } else {
+        print(message);
+      }
     }
     abort();
   };

--- a/src/template-string.ts
+++ b/src/template-string.ts
@@ -43,7 +43,18 @@ const createSingleConstant = <T extends MafiaClass>(
     try {
       return Type.get<I>(input);
     } catch (error) {
-      print(`${error}; you should probably update KoLmafia!`, "red");
+      const message = `${error}`;
+      const match = message.match(
+        RegExp(`Bad ${Type.name.toLowerCase()} value: (.*)`)
+      );
+      if (match) {
+        print(
+          `${match[0]}; if you're certain that this ${Type} exists and is spelled correctly, please update KoLMafia`,
+          "red"
+        );
+      } else {
+        print(message);
+      }
     }
     abort();
   };

--- a/src/template-string.ts
+++ b/src/template-string.ts
@@ -71,7 +71,8 @@ const createPluralConstant =
       );
       if (match) {
         print(
-          `${match[0]}; if you're certain that ${Type} exists and is spelled correctly, please update KoLMafia`
+          `${match[0]}; if you're certain that this ${Type} exists and is spelled correctly, please update KoLMafia`,
+          "red"
         );
       } else {
         print(message);

--- a/src/template-string.ts
+++ b/src/template-string.ts
@@ -31,6 +31,24 @@ const concatTemplateString = (
     ""
   );
 
+const handleTypeGetError = <T extends MafiaClass>(
+  Type: typeof MafiaClass & (new () => T),
+  error: unknown
+) => {
+  const message = `${error}`;
+  const match = message.match(
+    RegExp(`Bad ${Type.name.toLowerCase()} value: (.*)`)
+  );
+  if (match) {
+    print(
+      `${match[0]}; if you're certain that this ${Type} exists and is spelled correctly, please update KoLMafia`,
+      "red"
+    );
+  } else {
+    print(message);
+  }
+};
+
 const createSingleConstant = <T extends MafiaClass>(
   Type: typeof MafiaClass & (new () => T)
 ) => {
@@ -43,18 +61,7 @@ const createSingleConstant = <T extends MafiaClass>(
     try {
       return Type.get<I>(input);
     } catch (error) {
-      const message = `${error}`;
-      const match = message.match(
-        RegExp(`Bad ${Type.name.toLowerCase()} value: (.*)`)
-      );
-      if (match) {
-        print(
-          `${match[0]}; if you're certain that this ${Type} exists and is spelled correctly, please update KoLMafia`,
-          "red"
-        );
-      } else {
-        print(message);
-      }
+      handleTypeGetError(Type, error);
     }
     abort();
   };
@@ -76,18 +83,7 @@ const createPluralConstant =
     try {
       return Type.get<I>(splitByCommasWithEscapes(input));
     } catch (error) {
-      const message = `${error}`;
-      const match = message.match(
-        RegExp(`Bad ${Type.name.toLowerCase()} value: (.*)`)
-      );
-      if (match) {
-        print(
-          `${match[0]}; if you're certain that this ${Type} exists and is spelled correctly, please update KoLMafia`,
-          "red"
-        );
-      } else {
-        print(message);
-      }
+      handleTypeGetError(Type, error);
     }
     abort();
   };

--- a/src/template-string.ts
+++ b/src/template-string.ts
@@ -67,7 +67,7 @@ const createPluralConstant =
     } catch (error) {
       const message = `${error}`;
       const match = message.match(
-        RegExp(`Bad ${Type.name.toString()} value: (.*)`, "i")
+        RegExp(`Bad ${Type.name.toLowerCase()} value: (.*)`)
       );
       if (match) {
         print(


### PR DESCRIPTION
This is more of a pitch than a PR, but it solves the problem of mafia constants in top-level code throwing errors before our `since` check is triggered