### PR TITLE
Do not try to shove more food into an overflowing stomach

### DIFF
--- a/src/diet/index.ts
+++ b/src/diet/index.ts
@@ -495,17 +495,17 @@ class DietPlanner<T> {
     const organCapacitiesWithMap = new Map(organCapacities);
     for (const [organ, size] of organSizes) {
       const current = organCapacitiesWithMap.get(organ);
-      if (current !== undefined) {
-        organCapacitiesWithMap.set(organ, current - size);
-      } else {
-        // We are not tracking the status of this organ. Currently, it means that we are overfull, and the last thing we should try is to shove more stuff into it
-        // Solves the problem with the diet offering to eat toasted brie after exiting smol with 20/15 fullness
+      if (current === undefined) {
+        // Organs with no capacity are excluded from the organCapacities map, so this item excluded from the trial.
+        // Solves the problem with the diet offering to eat toasted brie after exiting Shrunken Adventurer with 20/15 fullness.
         return this.planOrgansWithTrials(
           organCapacities,
           trialItems.slice(1),
           overrideModifiers
         );
       }
+
+      organCapacitiesWithMap.set(organ, current - size);
     }
     const organCapacitiesWith = [...organCapacitiesWithMap];
 

--- a/src/diet/index.ts
+++ b/src/diet/index.ts
@@ -497,8 +497,7 @@ class DietPlanner<T> {
       const current = organCapacitiesWithMap.get(organ);
       if (current !== undefined) {
         organCapacitiesWithMap.set(organ, current - size);
-      }
-      else {
+      } else {
         // We are not tracking the status of this organ. Currently, it means that we are overfull, and the last thing we should try is to shove more stuff into it
         // Solves the problem with the diet offering to eat toasted brie after exiting smol with 20/15 fullness
         return this.planOrgansWithTrials(

--- a/src/diet/index.ts
+++ b/src/diet/index.ts
@@ -498,6 +498,15 @@ class DietPlanner<T> {
       if (current !== undefined) {
         organCapacitiesWithMap.set(organ, current - size);
       }
+      else {
+        // We are not tracking the status of this organ. Currently, it means that we are overfull, and the last thing we should try is to shove more stuff into it
+        // Solves the problem with the diet offering to eat toasted brie after exiting smol with 20/15 fullness
+        return this.planOrgansWithTrials(
+          organCapacities,
+          trialItems.slice(1),
+          overrideModifiers
+        );
+      }
     }
     const organCapacitiesWith = [...organCapacitiesWithMap];
 


### PR DESCRIPTION
Currently, if an organ is overfull, the diet planner code does the following:
- [removes that organ from future consideration](https://github.com/loathers/libram/blob/bf73eed32a0db1b019ea2f91884ed4553d720825/src/diet/index.ts#L669)
- runs planOrgansWithTrials
- happily adds more expenses of that resource since it is explicitly not tracked (current is undefined in [here](https://github.com/loathers/libram/blob/bf73eed32a0db1b019ea2f91884ed4553d720825/src/diet/index.ts#L498)).
It does not even make sense to consider organ cleaners there, since the state of an overfull organ is just plainly not tracked at all (perhaps it might be a task for the future to correctly process overfull organs and suggest organ cleaning if this is worth it). So, in the current implementation it is better to ignore any items that interact with overfull organs, rather than thinking that overfull means unlimited.

Please note that I did not test it, and I did not run yarn - but I don't think there are bugs in this commit.