### PR TITLE
Ascend object parameters and kolGender param

### DIFF
--- a/src/ascend.ts
+++ b/src/ascend.ts
@@ -235,6 +235,7 @@ function isInValhalla(): boolean {
  * @param params.path path of choice, as a Path object--these exist as properties of Paths
  * @param params.playerClass Your class of choice for this ascension
  * @param params.lifestyle 1 for casual, 2 for softcore, 3 for hardcore. Alternately, use the Lifestyle enum
+ * @param params.kolGender Unfortunately limited to male or female (as strings). Defaults to female, or the value of the defaultGenderOverride preference, if it is set.
  * @param params.moon Your moon sign as a string, or the zone you're looking for as a string
  * @param params.consumable From the astral deli. Pick the container item, not the product. Defaults to astral six-pack, provide $item`none` for nothing.
  * @param params.pet From the astral pet store.
@@ -246,6 +247,7 @@ export function ascend({
   path,
   playerClass,
   lifestyle,
+  kolGender,
   moon,
   consumable,
   pet,
@@ -254,6 +256,7 @@ export function ascend({
   path: Path;
   playerClass: Class;
   lifestyle: Lifestyle;
+  kolGender?: "male" | "female";
   moon: InputMoonSign;
   consumable?: Item;
   pet?: Item;
@@ -334,8 +337,13 @@ export function ascend({
     }
   }
 
+  kolGender =
+    kolGender ??
+    (get("kolGenderOverride", "female") === "male" ? "male" : "female");
+  const kolGenderId = kolGender === "male" ? "1" : "2";
+
   visitUrl(
-    `afterlife.php?action=ascend&confirmascend=1&whichsign=${moonId}&gender=2&whichclass=${playerClass.id}&whichpath=${path.id}&asctype=${lifestyle}&nopetok=1&noskillsok=1&lamepathok=1&lamesignok=1&pwd`,
+    `afterlife.php?action=ascend&confirmascend=1&whichsign=${moonId}&gender=${kolGenderId}&whichclass=${playerClass.id}&whichpath=${path.id}&asctype=${lifestyle}&nopetok=1&noskillsok=1&lamepathok=1&lamesignok=1&pwd`,
     true
   );
 }

--- a/src/ascend.ts
+++ b/src/ascend.ts
@@ -229,27 +229,36 @@ function isInValhalla(): boolean {
 }
 
 /**
- * Hops the gash, perming no skills
+ * Hops the gash, perming no skills by default
  *
- * @param path path of choice, as a Path object--these exist as properties of Paths
- * @param playerClass Your class of choice for this ascension
- * @param lifestyle 1 for casual, 2 for softcore, 3 for hardcore. Alternately, use the Lifestyle enum
- * @param moon Your moon sign as a string, or the zone you're looking for as a string
- * @param consumable From the astral deli. Pick the container item, not the product.
- * @param pet From the astral pet store.
- * @param permOptions Options for perming during a player's stay in Valhalla
- * @param permOptions.permSkills A Map<Skill, Lifestyle> of skills you'd like to perm, ordered by priority.
- * @param permOptions.neverAbort Whether the ascension shouold abort on failure
+ * @param params Configuration for the ascension
+ * @param params.path path of choice, as a Path object--these exist as properties of Paths
+ * @param params.playerClass Your class of choice for this ascension
+ * @param params.lifestyle 1 for casual, 2 for softcore, 3 for hardcore. Alternately, use the Lifestyle enum
+ * @param params.moon Your moon sign as a string, or the zone you're looking for as a string
+ * @param params.consumable From the astral deli. Pick the container item, not the product. Defaults to astral six-pack, provide $item`none` for nothing.
+ * @param params.pet From the astral pet store.
+ * @param params.permOptions Options for perming during a player's stay in Valhalla
+ * @param params.permOptions.permSkills A Map<Skill, Lifestyle> of skills you'd like to perm, ordered by priority.
+ * @param params.permOptions.neverAbort Whether the ascension should abort on failure
  */
-export function ascend(
-  path: Path,
-  playerClass: Class,
-  lifestyle: Lifestyle,
-  moon: InputMoonSign,
-  consumable: Item | undefined = $item`astral six-pack`,
-  pet: Item | undefined = undefined,
-  permOptions?: { permSkills: Map<Skill, Lifestyle>; neverAbort: boolean }
-): void {
+export function ascend({
+  path,
+  playerClass,
+  lifestyle,
+  moon,
+  consumable,
+  pet,
+  permOptions,
+}: {
+  path: Path;
+  playerClass: Class;
+  lifestyle: Lifestyle;
+  moon: InputMoonSign;
+  consumable?: Item;
+  pet?: Item;
+  permOptions?: { permSkills: Map<Skill, Lifestyle>; neverAbort: boolean };
+}): void {
   if (playerClass.path !== (path.avatar ? path : Path.none)) {
     throw new AscendError(playerClass);
   }
@@ -257,9 +266,13 @@ export function ascend(
 
   const moonId = inputToMoonId(moon, playerClass);
   if (moonId < 1 || moonId > 9) throw new Error(`Invalid moon ${moon}`);
+
+  if (consumable === undefined) {
+    consumable = $item`astral six-pack`;
+  }
   if (
     consumable &&
-    !$items`astral six-pack, astral hot dog dinner, [10882]carton of astral energy drinks`.includes(
+    !$items`none, astral six-pack, astral hot dog dinner, [10882]carton of astral energy drinks`.includes(
       consumable
     )
   ) {
@@ -293,7 +306,7 @@ export function ascend(
 
   visitUrl("afterlife.php?action=pearlygates");
 
-  if (consumable) {
+  if (consumable !== $item`none`) {
     visitUrl(`afterlife.php?action=buydeli&whichitem=${consumable.id}`);
   }
 

--- a/src/ascend.ts
+++ b/src/ascend.ts
@@ -236,19 +236,19 @@ function isInValhalla(): boolean {
 /**
  * Hops the gash, perming no skills by default
  *
- * @param inputValues Configuration for the ascension
- * @param inputValues.path path of choice, as a Path object--these exist as properties of Paths
- * @param inputValues.playerClass Your class of choice for this ascension
- * @param inputValues.lifestyle 1 for casual, 2 for softcore, 3 for hardcore. Alternately, use the Lifestyle enum
- * @param inputValues.kolGender An entry from the KolGender enum: 1 for male, 2 for female (sorry that it's limited to those). Defaults to 2 or the corresponding value for defaultGenderOverride pref (which should be 'male' or 'female')
- * @param inputValues.moon Your moon sign as a string, or the zone you're looking for as a string
- * @param inputValues.consumable From the astral deli. Pick the container item, not the product. Defaults to astral six-pack, provide $item`none` for nothing.
- * @param inputValues.pet From the astral pet store.
- * @param inputValues.permOptions Options for perming during a player's stay in Valhalla
- * @param inputValues.permOptions.permSkills A Map<Skill, Lifestyle> of skills you'd like to perm, ordered by priority.
- * @param inputValues.permOptions.neverAbort Whether the ascension should abort on failure
+ * @param options Configuration for the ascension
+ * @param options.path path of choice, as a Path object--these exist as properties of Paths
+ * @param options.playerClass Your class of choice for this ascension
+ * @param options.lifestyle 1 for casual, 2 for softcore, 3 for hardcore. Alternately, use the Lifestyle enum
+ * @param options.kolGender An entry from the KolGender enum: 1 for male, 2 for female (sorry that it's limited to those). Defaults to 2 or the corresponding value for defaultGenderOverride pref (which should be 'male' or 'female')
+ * @param options.moon Your moon sign as a string, or the zone you're looking for as a string
+ * @param options.consumable From the astral deli. Pick the container item, not the product. Defaults to astral six-pack, provide $item`none` for nothing.
+ * @param options.pet From the astral pet store.
+ * @param options.permOptions Options for perming during a player's stay in Valhalla
+ * @param options.permOptions.permSkills A Map<Skill, Lifestyle> of skills you'd like to perm, ordered by priority.
+ * @param options.permOptions.neverAbort Whether the ascension should abort on failure
  */
-export function ascend(inputValues: {
+export function ascend(options: {
   path: Path;
   playerClass: Class;
   lifestyle: Lifestyle;
@@ -258,7 +258,7 @@ export function ascend(inputValues: {
   pet?: Item;
   permOptions?: { permSkills: Map<Skill, Lifestyle>; neverAbort: boolean };
 }): void {
-  const DEFAULT_VALUES = {
+  const DEFAULT_OPTIONS = {
     kolGender:
       get("defaultGenderOverride", "female") === "male"
         ? KolGender.male
@@ -275,7 +275,7 @@ export function ascend(inputValues: {
     consumable,
     pet,
     permOptions,
-  } = { ...DEFAULT_VALUES, ...inputValues };
+  } = { ...DEFAULT_OPTIONS, ...options };
 
   if (playerClass.path !== (path.avatar ? path : Path.none)) {
     throw new AscendError(playerClass);
@@ -286,8 +286,7 @@ export function ascend(inputValues: {
   if (moonId < 1 || moonId > 9) throw new Error(`Invalid moon ${moon}`);
 
   if (
-    consumable !== $item`none` &&
-    !$items`astral six-pack, astral hot dog dinner, [10882]carton of astral energy drinks`.includes(
+    !$items`none, astral six-pack, astral hot dog dinner, [10882]carton of astral energy drinks`.includes(
       consumable
     )
   ) {
@@ -295,8 +294,7 @@ export function ascend(inputValues: {
   }
 
   if (
-    pet !== $item`none` &&
-    !$items`astral bludgeon, astral shield, astral chapeau, astral bracer, astral longbow, astral shorts, astral mace, astral trousers, astral ring, astral statuette, astral pistol, astral mask, astral pet sweater, astral shirt, astral belt`.includes(
+    !$items`none, astral bludgeon, astral shield, astral chapeau, astral bracer, astral longbow, astral shorts, astral mace, astral trousers, astral ring, astral statuette, astral pistol, astral mask, astral pet sweater, astral shirt, astral belt`.includes(
       pet
     )
   ) {


### PR DESCRIPTION
Per some discussion earlier on discord, this PR switches the `ascend` function to take an object containing its parameters instead of a lengthy list of parameters you have to remember the order of and sub in undefined for to default and so on. While I was at it, I added the KolGender enum and support for `defaultGenderOverride` preference to specify what gender to ascend as, instead of always going female. It still defaults to female for those who don't specify something though.

THIS IS A BREAKING CHANGE. It will require a version update. I asked if I should keep the old version around to prevent breaking things that update, and was told it would be acceptable to do it this way, and so I did. Not sure if I'm supposed to bump the version as part of this PR or if that happens in a follow up change, so I haven't done it yet.

This is my first libram PR, so let me know if I missed any steps. I did run formatting and linting, at least.