### PR TITLE
Fix fractional potion mood

### DIFF
--- a/src/mood.ts
+++ b/src/mood.ts
@@ -223,8 +223,8 @@ class PotionMoodElement extends MoodElement {
     // fractional part
     const remainingDifference = ensureTurns - haveEffect(effect);
     if (remainingDifference > 0) {
-      const price = Math.floor(this.maxPricePerTurn * remainingDifference);
-      if (price <= mallPrice(this.potion)) {
+      const maxPrice = Math.floor(this.maxPricePerTurn * remainingDifference);
+      if (mallPrice(this.potion) <= maxPrice) {
         if (availableAmount(this.potion) || buy(1, this.potion, price)) {
           use(1, this.potion);
         }

--- a/src/mood.ts
+++ b/src/mood.ts
@@ -225,7 +225,7 @@ class PotionMoodElement extends MoodElement {
     if (remainingDifference > 0) {
       const maxPrice = Math.floor(this.maxPricePerTurn * remainingDifference);
       if (mallPrice(this.potion) <= maxPrice) {
-        if (availableAmount(this.potion) || buy(1, this.potion, price)) {
+        if (availableAmount(this.potion) || buy(1, this.potion, maxPrice)) {
           use(1, this.potion);
         }
       }


### PR DESCRIPTION
This used to only buy potions when mall price was higher than the max price