### PR TITLE
updateOnLocationChanged for Outfit

### DIFF
--- a/src/maximize.ts
+++ b/src/maximize.ts
@@ -352,7 +352,7 @@ function checkCache(
 
   if (options.updateOnLocationChange && myLocation() !== entry.location) {
     logger.warning(
-      "Equipment found in maximize cache but familiar is different."
+      "Equipment found in maximize cache but location is different."
     );
     return null;
   }


### PR DESCRIPTION
This is useful for item farming scripts where zones can have modifiers on them (Florist friars etc) and we don't want to overcap item drop.

Default is false because I think for the most part in KoL this isn't that relevant