### PR TITLE
Resolve circular imports

### DIFF
--- a/src/ascend.ts
+++ b/src/ascend.ts
@@ -13,6 +13,7 @@ import {
   getPermedSkills,
   toSkill,
 } from "kolmafia";
+import { MoonSign, signNameToId } from "./moonSign";
 import { get } from "./property";
 import { ChateauMantegna } from "./resources";
 import { $item, $items, $stat } from "./template-string";
@@ -128,20 +129,6 @@ export class AscensionPrepError extends Error {
   }
 }
 
-const MoonSigns = [
-  "Mongoose",
-  "Wallaby",
-  "Vole",
-  "Platypus",
-  "Opossum",
-  "Marmot",
-  "Wombat",
-  "Blender",
-  "Packrat",
-] as const;
-
-type MoonSign = typeof MoonSigns[number];
-
 type InputMoonSign =
   | number
   | Lowercase<MoonSign>
@@ -155,22 +142,6 @@ type InputMoonSign =
   | "gnomads"
   | "gnomish"
   | "gnomish gnomads camp";
-
-/**
- * @param moon Moon sign name
- * @returns Moon sign id else 0
- */
-export function signNameToId(moon: MoonSign): number {
-  return MoonSigns.indexOf(moon) + 1;
-}
-
-/**
- * @param id Moon sign id
- * @returns Name of moon sign else "None"
- */
-export function signIdToName(id: number): MoonSign | "None" {
-  return MoonSigns[id - 1] || "None";
-}
 
 /**
  * Determine the id of the appropriate moon sign.

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ export {
   skillModifiers,
 } from "./modifierTypes";
 export * from "./mood";
+export * from "./moonSign";
 export * from "./propertyTyping";
 export * from "./resources";
 export * from "./since";

--- a/src/moonSign.ts
+++ b/src/moonSign.ts
@@ -1,0 +1,28 @@
+const MoonSigns = [
+  "Mongoose",
+  "Wallaby",
+  "Vole",
+  "Platypus",
+  "Opossum",
+  "Marmot",
+  "Wombat",
+  "Blender",
+  "Packrat",
+] as const;
+export type MoonSign = typeof MoonSigns[number];
+
+/**
+ * @param moon Moon sign name
+ * @returns Moon sign id else 0
+ */
+export function signNameToId(moon: MoonSign): number {
+  return MoonSigns.indexOf(moon) + 1;
+}
+
+/**
+ * @param id Moon sign id
+ * @returns Name of moon sign else "None"
+ */
+export function signIdToName(id: number): MoonSign | "None" {
+  return MoonSigns[id - 1] || "None";
+}

--- a/src/resources/2019/CampAway.ts
+++ b/src/resources/2019/CampAway.ts
@@ -7,7 +7,7 @@ import {
   use,
   visitUrl,
 } from "kolmafia";
-import { signIdToName } from "../../ascend";
+import { signIdToName } from "../../moonSign";
 import { get, withChoice } from "../../property";
 import { $item } from "../../template-string";
 import { random } from "../../utils";

--- a/src/resources/2021/CrystalBall.ts
+++ b/src/resources/2021/CrystalBall.ts
@@ -9,8 +9,8 @@ import {
   myTotalTurnsSpent,
   totalTurnsPlayed,
 } from "kolmafia";
-import { logger } from "../..";
 import { canVisitUrl } from "../../lib";
+import logger from "../../logger";
 import { get } from "../../property";
 
 export const orb = Item.get("miniature crystal ball");


### PR DESCRIPTION
There are two circular imports involving CrystalBall and CampAway. The first one is an easy fix, the latter requires MoonSign to be moved to its own module, which seems sensible anyway, though.