### PR TITLE
Fix check for Jumping in the Flames

### DIFF
--- a/src/resources/2023/BurningLeaves.ts
+++ b/src/resources/2023/BurningLeaves.ts
@@ -65,11 +65,17 @@ function visitLeaves() {
 }
 
 /**
- * Checks whether you can, then jumps into the fire
+ * Checks whether you can, then Jumps in the Flames
+ * @returns Whether or not you jumped in the flames
  */
-export function jumpInFire(): void {
-  if (!get("_leavesJumped", false)) {
-    visitLeaves();
-    runChoice(2);
+export function jumpInFire(): boolean {
+  if (get("_leavesJumped")) {
+    return false;
   }
+  if (get("_leavesBurned") === 0) {
+    return false;
+  }
+  visitLeaves();
+  runChoice(2);
+  return get("_leavesJumped");
 }

--- a/src/resources/2023/BurningLeaves.ts
+++ b/src/resources/2023/BurningLeaves.ts
@@ -68,7 +68,7 @@ function visitLeaves() {
  * Checks whether you can, then jumps into the fire
  */
 export function jumpInFire(): void {
-  if (get("_leavesJumped", false)) {
+  if (!get("_leavesJumped", false)) {
     visitLeaves();
     runChoice(2);
   }


### PR DESCRIPTION
Found another twisted predicate (sorry I missed that before). Also added a check whether there are any leaves to jump in, and a return value whether the jump was successful.