### PR TITLE
Properly encode message parameter in KMail.send

### DIFF
--- a/__tests__/Kmail.ts
+++ b/__tests__/Kmail.ts
@@ -1,0 +1,162 @@
+import { isGiftable, Item, visitUrl } from "kolmafia";
+import { $item, Kmail } from "../src";
+
+import mocked = jest.mocked;
+
+jest.mock("kolmafia");
+
+const USER = 11;
+
+const mockItem1 = $item`Jumbo Dr. Lucifer`;
+const mockItem2 = $item`worthless trinket`;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe(Kmail.send, () => {
+  beforeEach(() => {
+    mocked(visitUrl).mockReturnValue(`<div>Message sent.</div>`);
+    mocked(isGiftable).mockReturnValue(true);
+  });
+
+  it("should send a kmail with a message", () => {
+    Kmail.send(USER, "Hello, world!");
+
+    expect(visitUrl).toHaveBeenCalledWith(
+      "sendmessage.php?action=send&pwd&towho=11&message=Hello, world!&sendmeat=0"
+    );
+  });
+
+  it("should send a kmail with a message and meat", () => {
+    Kmail.send(USER, "Hello, world!", [], 100);
+
+    expect(visitUrl).toHaveBeenCalledWith(
+      "sendmessage.php?action=send&pwd&towho=11&message=Hello, world!&sendmeat=100"
+    );
+  });
+
+  it("should send a kmail with a message and items", () => {
+    Kmail.send(USER, "Hello, world!", [mockItem1]);
+
+    expect(visitUrl).toHaveBeenCalledWith(
+      `sendmessage.php?action=send&pwd&towho=11&message=Hello, world!&whichitem1=${mockItem1.id}&howmany1=1&sendmeat=0`
+    );
+  });
+
+  it("should send a kmail with a message, items, and meat", () => {
+    Kmail.send(
+      USER,
+      "Hello, world!",
+      new Map([
+        [mockItem1, 11],
+        [mockItem2, 42],
+      ]),
+      100
+    );
+
+    expect(visitUrl).toHaveBeenCalledWith(
+      `sendmessage.php?action=send&pwd&towho=11&message=Hello, world!&whichitem1=${mockItem1.id}&howmany1=11&whichitem2=${mockItem2.id}&howmany2=42&sendmeat=100`
+    );
+  });
+
+  it("should send at most 11 items per chunk", () => {
+    const mockItems = Array(15)
+      .fill(undefined)
+      .map((_, i) => Item.get(`mock item ${i}`));
+
+    Kmail.send(USER, "Hello, world!", mockItems, 100);
+
+    expect(visitUrl).toHaveBeenCalledTimes(2);
+    expect(visitUrl).toHaveBeenNthCalledWith(
+      1,
+      `sendmessage.php?action=send&pwd&towho=11&message=Hello, world!&whichitem1=${mockItems[0].id}&howmany1=1&whichitem2=${mockItems[1].id}&howmany2=1&whichitem3=${mockItems[2].id}&howmany3=1&whichitem4=${mockItems[3].id}&howmany4=1&whichitem5=${mockItems[4].id}&howmany5=1&whichitem6=${mockItems[5].id}&howmany6=1&whichitem7=${mockItems[6].id}&howmany7=1&whichitem8=${mockItems[7].id}&howmany8=1&whichitem9=${mockItems[8].id}&howmany9=1&whichitem10=${mockItems[9].id}&howmany10=1&whichitem11=${mockItems[10].id}&howmany11=1&sendmeat=100`
+    );
+    expect(visitUrl).toHaveBeenNthCalledWith(
+      2,
+      `sendmessage.php?action=send&pwd&towho=11&message=Hello, world!&whichitem1=${mockItems[11].id}&howmany1=1&whichitem2=${mockItems[12].id}&howmany2=1&whichitem3=${mockItems[13].id}&howmany3=1&whichitem4=${mockItems[14].id}&howmany4=1&sendmeat=0`
+    );
+  });
+
+  it.todo(
+    "should send a kmail with a message, items, and meat, and skip ungiftable items"
+  );
+
+  it.todo(
+    "should fallback to sending a gift if the user cannot receive meat or items"
+  );
+});
+
+describe(Kmail.gift, () => {
+  it("should send a gift with a message", () => {
+    Kmail.gift(USER, "Hello, world!");
+
+    expect(visitUrl).toHaveBeenCalledWith(
+      "town_sendgift.php?action=Yep.&pwd&fromwhere=0&note=Hello, world!&insidenote=&towho=11&whichpackage=0&sendmeat=0"
+    );
+  });
+
+  it("should send a gift with a message and an inside note", () => {
+    Kmail.gift(
+      USER,
+      "Hello, world!",
+      undefined,
+      undefined,
+      "This is not even funny."
+    );
+
+    expect(visitUrl).toHaveBeenCalledWith(
+      "town_sendgift.php?action=Yep.&pwd&fromwhere=0&note=Hello, world!&insidenote=This is not even funny.&towho=11&whichpackage=0&sendmeat=0"
+    );
+  });
+
+  it("should send a gift with a message and meat", () => {
+    Kmail.gift(USER, "Hello, world!", [], 100);
+
+    expect(visitUrl).toHaveBeenCalledWith(
+      "town_sendgift.php?action=Yep.&pwd&fromwhere=0&note=Hello, world!&insidenote=&towho=11&whichpackage=0&sendmeat=100"
+    );
+  });
+
+  it("should send a gift with a message and one item", () => {
+    Kmail.gift(USER, "Hello, world!", [mockItem1]);
+
+    expect(visitUrl).toHaveBeenCalledWith(
+      `town_sendgift.php?action=Yep.&pwd&fromwhere=0&note=Hello, world!&insidenote=&towho=11&whichpackage=1&whichitem1=${mockItem1.id}&howmany1=1&sendmeat=0`
+    );
+  });
+
+  it("should send a gift with a message and multiple items", () => {
+    Kmail.gift(
+      USER,
+      "Hello, world!",
+      new Map([
+        [mockItem1, 11],
+        [mockItem2, 42],
+      ]),
+      100
+    );
+
+    expect(visitUrl).toHaveBeenCalledWith(
+      `town_sendgift.php?action=Yep.&pwd&fromwhere=0&note=Hello, world!&insidenote=&towho=11&whichpackage=2&whichitem1=${mockItem1.id}&howmany1=11&whichitem2=${mockItem2.id}&howmany2=42&sendmeat=100`
+    );
+  });
+
+  it("should send at most 3 items per chunk", () => {
+    const mockItems = Array(5)
+      .fill(undefined)
+      .map((_, i) => Item.get(`mock item ${i}`));
+
+    Kmail.gift(USER, "Hello, world!", mockItems, 100);
+
+    expect(visitUrl).toHaveBeenCalledTimes(2);
+    expect(visitUrl).toHaveBeenNthCalledWith(
+      1,
+      `town_sendgift.php?action=Yep.&pwd&fromwhere=0&note=Hello, world!&insidenote=&towho=11&whichpackage=3&whichitem1=${mockItems[0].id}&howmany1=1&whichitem2=${mockItems[1].id}&howmany2=1&whichitem3=${mockItems[2].id}&howmany3=1&sendmeat=100`
+    );
+    expect(visitUrl).toHaveBeenNthCalledWith(
+      2,
+      `town_sendgift.php?action=Yep.&pwd&fromwhere=0&note=Hello, world!&insidenote=&towho=11&whichpackage=2&whichitem1=${mockItems[3].id}&howmany1=1&whichitem2=${mockItems[4].id}&howmany2=1&sendmeat=0`
+    );
+  });
+});

--- a/__tests__/Kmail.ts
+++ b/__tests__/Kmail.ts
@@ -24,7 +24,9 @@ describe(Kmail.send, () => {
     Kmail.send(USER, "Hello, world!");
 
     expect(visitUrl).toHaveBeenCalledWith(
-      "sendmessage.php?action=send&pwd&towho=11&message=Hello, world!&sendmeat=0"
+      "sendmessage.php?action=send&pwd&towho=11&message=Hello%2C%20world!&sendmeat=0",
+      true,
+      true
     );
   });
 
@@ -32,7 +34,9 @@ describe(Kmail.send, () => {
     Kmail.send(USER, "Hello, world!", [], 100);
 
     expect(visitUrl).toHaveBeenCalledWith(
-      "sendmessage.php?action=send&pwd&towho=11&message=Hello, world!&sendmeat=100"
+      "sendmessage.php?action=send&pwd&towho=11&message=Hello%2C%20world!&sendmeat=100",
+      true,
+      true
     );
   });
 
@@ -40,7 +44,9 @@ describe(Kmail.send, () => {
     Kmail.send(USER, "Hello, world!", [mockItem1]);
 
     expect(visitUrl).toHaveBeenCalledWith(
-      `sendmessage.php?action=send&pwd&towho=11&message=Hello, world!&whichitem1=${mockItem1.id}&howmany1=1&sendmeat=0`
+      `sendmessage.php?action=send&pwd&towho=11&message=Hello%2C%20world!&sendmeat=0&whichitem1=${mockItem1.id}&howmany1=1`,
+      true,
+      true
     );
   });
 
@@ -56,7 +62,9 @@ describe(Kmail.send, () => {
     );
 
     expect(visitUrl).toHaveBeenCalledWith(
-      `sendmessage.php?action=send&pwd&towho=11&message=Hello, world!&whichitem1=${mockItem1.id}&howmany1=11&whichitem2=${mockItem2.id}&howmany2=42&sendmeat=100`
+      `sendmessage.php?action=send&pwd&towho=11&message=Hello%2C%20world!&sendmeat=100&whichitem1=${mockItem1.id}&howmany1=11&whichitem2=${mockItem2.id}&howmany2=42`,
+      true,
+      true
     );
   });
 
@@ -70,11 +78,15 @@ describe(Kmail.send, () => {
     expect(visitUrl).toHaveBeenCalledTimes(2);
     expect(visitUrl).toHaveBeenNthCalledWith(
       1,
-      `sendmessage.php?action=send&pwd&towho=11&message=Hello, world!&whichitem1=${mockItems[0].id}&howmany1=1&whichitem2=${mockItems[1].id}&howmany2=1&whichitem3=${mockItems[2].id}&howmany3=1&whichitem4=${mockItems[3].id}&howmany4=1&whichitem5=${mockItems[4].id}&howmany5=1&whichitem6=${mockItems[5].id}&howmany6=1&whichitem7=${mockItems[6].id}&howmany7=1&whichitem8=${mockItems[7].id}&howmany8=1&whichitem9=${mockItems[8].id}&howmany9=1&whichitem10=${mockItems[9].id}&howmany10=1&whichitem11=${mockItems[10].id}&howmany11=1&sendmeat=100`
+      `sendmessage.php?action=send&pwd&towho=11&message=Hello%2C%20world!&sendmeat=100&whichitem1=${mockItems[0].id}&howmany1=1&whichitem2=${mockItems[1].id}&howmany2=1&whichitem3=${mockItems[2].id}&howmany3=1&whichitem4=${mockItems[3].id}&howmany4=1&whichitem5=${mockItems[4].id}&howmany5=1&whichitem6=${mockItems[5].id}&howmany6=1&whichitem7=${mockItems[6].id}&howmany7=1&whichitem8=${mockItems[7].id}&howmany8=1&whichitem9=${mockItems[8].id}&howmany9=1&whichitem10=${mockItems[9].id}&howmany10=1&whichitem11=${mockItems[10].id}&howmany11=1`,
+      true,
+      true
     );
     expect(visitUrl).toHaveBeenNthCalledWith(
       2,
-      `sendmessage.php?action=send&pwd&towho=11&message=Hello, world!&whichitem1=${mockItems[11].id}&howmany1=1&whichitem2=${mockItems[12].id}&howmany2=1&whichitem3=${mockItems[13].id}&howmany3=1&whichitem4=${mockItems[14].id}&howmany4=1&sendmeat=0`
+      `sendmessage.php?action=send&pwd&towho=11&message=Hello%2C%20world!&sendmeat=0&whichitem1=${mockItems[11].id}&howmany1=1&whichitem2=${mockItems[12].id}&howmany2=1&whichitem3=${mockItems[13].id}&howmany3=1&whichitem4=${mockItems[14].id}&howmany4=1`,
+      true,
+      true
     );
   });
 
@@ -85,6 +97,16 @@ describe(Kmail.send, () => {
   it.todo(
     "should fallback to sending a gift if the user cannot receive meat or items"
   );
+
+  it("should properly encode ampersand characters", () => {
+    Kmail.send(USER, "Hi there, give me all your money!&sendmeat=10000000000");
+
+    expect(visitUrl).toHaveBeenCalledWith(
+      "sendmessage.php?action=send&pwd&towho=11&message=Hi%20there%2C%20give%20me%20all%20your%20money!%26sendmeat%3D10000000000&sendmeat=0",
+      true,
+      true
+    );
+  });
 });
 
 describe(Kmail.gift, () => {
@@ -92,7 +114,9 @@ describe(Kmail.gift, () => {
     Kmail.gift(USER, "Hello, world!");
 
     expect(visitUrl).toHaveBeenCalledWith(
-      "town_sendgift.php?action=Yep.&pwd&fromwhere=0&note=Hello, world!&insidenote=&towho=11&whichpackage=0&sendmeat=0"
+      "town_sendgift.php?action=Yep.&pwd&fromwhere=0&note=Hello%2C%20world!&insidenote=&towho=11&whichpackage=0&sendmeat=0",
+      true,
+      true
     );
   });
 
@@ -106,7 +130,9 @@ describe(Kmail.gift, () => {
     );
 
     expect(visitUrl).toHaveBeenCalledWith(
-      "town_sendgift.php?action=Yep.&pwd&fromwhere=0&note=Hello, world!&insidenote=This is not even funny.&towho=11&whichpackage=0&sendmeat=0"
+      "town_sendgift.php?action=Yep.&pwd&fromwhere=0&note=Hello%2C%20world!&insidenote=This%20is%20not%20even%20funny.&towho=11&whichpackage=0&sendmeat=0",
+      true,
+      true
     );
   });
 
@@ -114,7 +140,9 @@ describe(Kmail.gift, () => {
     Kmail.gift(USER, "Hello, world!", [], 100);
 
     expect(visitUrl).toHaveBeenCalledWith(
-      "town_sendgift.php?action=Yep.&pwd&fromwhere=0&note=Hello, world!&insidenote=&towho=11&whichpackage=0&sendmeat=100"
+      "town_sendgift.php?action=Yep.&pwd&fromwhere=0&note=Hello%2C%20world!&insidenote=&towho=11&whichpackage=0&sendmeat=100",
+      true,
+      true
     );
   });
 
@@ -122,7 +150,9 @@ describe(Kmail.gift, () => {
     Kmail.gift(USER, "Hello, world!", [mockItem1]);
 
     expect(visitUrl).toHaveBeenCalledWith(
-      `town_sendgift.php?action=Yep.&pwd&fromwhere=0&note=Hello, world!&insidenote=&towho=11&whichpackage=1&whichitem1=${mockItem1.id}&howmany1=1&sendmeat=0`
+      `town_sendgift.php?action=Yep.&pwd&fromwhere=0&note=Hello%2C%20world!&insidenote=&towho=11&whichpackage=1&sendmeat=0&whichitem1=${mockItem1.id}&howmany1=1`,
+      true,
+      true
     );
   });
 
@@ -138,7 +168,9 @@ describe(Kmail.gift, () => {
     );
 
     expect(visitUrl).toHaveBeenCalledWith(
-      `town_sendgift.php?action=Yep.&pwd&fromwhere=0&note=Hello, world!&insidenote=&towho=11&whichpackage=2&whichitem1=${mockItem1.id}&howmany1=11&whichitem2=${mockItem2.id}&howmany2=42&sendmeat=100`
+      `town_sendgift.php?action=Yep.&pwd&fromwhere=0&note=Hello%2C%20world!&insidenote=&towho=11&whichpackage=2&sendmeat=100&whichitem1=${mockItem1.id}&howmany1=11&whichitem2=${mockItem2.id}&howmany2=42`,
+      true,
+      true
     );
   });
 
@@ -152,11 +184,15 @@ describe(Kmail.gift, () => {
     expect(visitUrl).toHaveBeenCalledTimes(2);
     expect(visitUrl).toHaveBeenNthCalledWith(
       1,
-      `town_sendgift.php?action=Yep.&pwd&fromwhere=0&note=Hello, world!&insidenote=&towho=11&whichpackage=3&whichitem1=${mockItems[0].id}&howmany1=1&whichitem2=${mockItems[1].id}&howmany2=1&whichitem3=${mockItems[2].id}&howmany3=1&sendmeat=100`
+      `town_sendgift.php?action=Yep.&pwd&fromwhere=0&note=Hello%2C%20world!&insidenote=&towho=11&whichpackage=3&sendmeat=100&whichitem1=${mockItems[0].id}&howmany1=1&whichitem2=${mockItems[1].id}&howmany2=1&whichitem3=${mockItems[2].id}&howmany3=1`,
+      true,
+      true
     );
     expect(visitUrl).toHaveBeenNthCalledWith(
       2,
-      `town_sendgift.php?action=Yep.&pwd&fromwhere=0&note=Hello, world!&insidenote=&towho=11&whichpackage=2&whichitem1=${mockItems[3].id}&howmany1=1&whichitem2=${mockItems[4].id}&howmany2=1&sendmeat=0`
+      `town_sendgift.php?action=Yep.&pwd&fromwhere=0&note=Hello%2C%20world!&insidenote=&towho=11&whichpackage=2&sendmeat=0&whichitem1=${mockItems[3].id}&howmany1=1&whichitem2=${mockItems[4].id}&howmany2=1`,
+      true,
+      true
     );
   });
 });

--- a/__tests__/__mocks__/kolmafia.ts
+++ b/__tests__/__mocks__/kolmafia.ts
@@ -1,0 +1,173 @@
+function mockOneOrMany<
+  Ctor extends new (name: string) => T,
+  T extends MafiaClass
+>(
+  ctor: Ctor,
+  n: number | string | (number | string)[],
+  knownInstances: T[]
+): T | T[] {
+  function mockOne(name: number | string): T {
+    // to make mocking easier, we'll just tread ids as names
+    if (typeof name === "number") {
+      name = name.toString();
+    }
+    const existingInstance = knownInstances.find((i) => i.name === name);
+    if (existingInstance) {
+      return existingInstance;
+    }
+    const instance = new ctor(name);
+    knownInstances.push(instance);
+    return instance;
+  }
+
+  if (Array.isArray(n)) {
+    return n.map((name) => mockOne(name));
+  }
+  return mockOne(n);
+}
+
+abstract class MafiaClass {
+  constructor(readonly name: string) {}
+}
+
+export class Bounty extends MafiaClass {
+  private static knownInstances: Bounty[] = [];
+  static get = jest.fn((n) => mockOneOrMany(Bounty, n, Bounty.knownInstances));
+  static all = jest.fn(() => Bounty.knownInstances);
+  static none = {};
+}
+export class Class extends MafiaClass {
+  private static knownInstances: Class[] = [];
+  static get = jest.fn((n) => mockOneOrMany(Class, n, Class.knownInstances));
+  static all = jest.fn(() => Class.knownInstances);
+  static none = {};
+}
+export class Coinmaster extends MafiaClass {
+  private static knownInstances: Coinmaster[] = [];
+  static get = jest.fn((n) =>
+    mockOneOrMany(Coinmaster, n, Coinmaster.knownInstances)
+  );
+  static all = jest.fn(() => Coinmaster.knownInstances);
+  static none = {};
+}
+export class Effect extends MafiaClass {
+  private static knownInstances: Effect[] = [];
+  static get = jest.fn((n) => mockOneOrMany(Effect, n, Effect.knownInstances));
+  static all = jest.fn(() => Effect.knownInstances);
+  static none = {};
+}
+export class Element extends MafiaClass {
+  private static knownInstances: Element[] = [];
+  static get = jest.fn((n) =>
+    mockOneOrMany(Element, n, Element.knownInstances)
+  );
+  static all = jest.fn(() => Element.knownInstances);
+  static none = {};
+}
+export class Familiar extends MafiaClass {
+  private static knownInstances: Familiar[] = [];
+  static get = jest.fn((n) =>
+    mockOneOrMany(Familiar, n, Familiar.knownInstances)
+  );
+  static all = jest.fn(() => Familiar.knownInstances);
+  static none = {};
+}
+export class Item extends MafiaClass {
+  private static knownInstances: Item[] = [];
+  private static mockId = 11;
+  static get = jest.fn((n) => mockOneOrMany(Item, n, Item.knownInstances));
+  static all = jest.fn(() => Item.knownInstances);
+  static none = new Item("", -1, "");
+
+  constructor(
+    readonly name: string,
+    readonly id: number = ++Item.mockId,
+    readonly plural: string = `Multiple ${name}`
+  ) {
+    super(name);
+  }
+}
+
+export class Location extends MafiaClass {
+  private static knownInstances: Location[] = [];
+  static get = jest.fn((n) =>
+    mockOneOrMany(Location, n, Location.knownInstances)
+  );
+  static all = jest.fn(() => Location.knownInstances);
+  static none = {};
+}
+export class Modifier extends MafiaClass {
+  private static knownInstances: Modifier[] = [];
+  static get = jest.fn((n) =>
+    mockOneOrMany(Modifier, n, Modifier.knownInstances)
+  );
+  static all = jest.fn(() => Modifier.knownInstances);
+  static none = {};
+}
+export class Monster extends MafiaClass {
+  private static knownInstances: Monster[] = [];
+  static get = jest.fn((n) =>
+    mockOneOrMany(Monster, n, Monster.knownInstances)
+  );
+  static all = jest.fn(() => Monster.knownInstances);
+  static none = {};
+}
+export class Path extends MafiaClass {
+  private static knownInstances: Path[] = [];
+  static get = jest.fn((n) => mockOneOrMany(Path, n, Path.knownInstances));
+  static all = jest.fn(() => Path.knownInstances);
+  static none = {};
+}
+export class Phylum extends MafiaClass {
+  private static knownInstances: Phylum[] = [];
+  static get = jest.fn((n) => mockOneOrMany(Phylum, n, Phylum.knownInstances));
+  static all = jest.fn(() => Phylum.knownInstances);
+  static none = {};
+}
+export class Servant extends MafiaClass {
+  private static knownInstances: Servant[] = [];
+  static get = jest.fn((n) =>
+    mockOneOrMany(Servant, n, Servant.knownInstances)
+  );
+  static all = jest.fn(() => Servant.knownInstances);
+  static none = {};
+}
+export class Skill extends MafiaClass {
+  private static knownInstances: Skill[] = [];
+  static get = jest.fn((n) => mockOneOrMany(Skill, n, Skill.knownInstances));
+  static all = jest.fn(() => Skill.knownInstances);
+  static none = {};
+}
+export class Slot extends MafiaClass {
+  private static knownInstances: Slot[] = [];
+  static get = jest.fn((n) => mockOneOrMany(Slot, n, Slot.knownInstances));
+  static all = jest.fn(() => Slot.knownInstances);
+  static none = {};
+}
+export class Stat extends MafiaClass {
+  private static knownInstances: Stat[] = [];
+  static get = jest.fn((n) => mockOneOrMany(Stat, n, Stat.knownInstances));
+  static all = jest.fn(() => Stat.knownInstances);
+  static none = {};
+}
+export class Thrall extends MafiaClass {
+  private static knownInstances: Thrall[] = [];
+  static get = jest.fn((n) => mockOneOrMany(Thrall, n, Thrall.knownInstances));
+  static all = jest.fn(() => Thrall.knownInstances);
+  static none = {};
+}
+export class Vykea extends MafiaClass {
+  private static knownInstances: Vykea[] = [];
+  static get = jest.fn((n) => mockOneOrMany(Vykea, n, Vykea.knownInstances));
+  static all = jest.fn(() => Vykea.knownInstances);
+  static none = {};
+}
+
+export const getProperty = jest.fn();
+
+export const isGiftable = jest.fn();
+
+export const print = jest.fn((msg) => console.log(`[kolmafia.print] ${msg}`));
+
+export const toItem = jest.fn((name) => Item.get(name));
+export const visitUrl = jest.fn();

--- a/__tests__/url.ts
+++ b/__tests__/url.ts
@@ -1,0 +1,191 @@
+import { visitUrl } from "kolmafia";
+
+import { buildUrl, combineQuery, EMPTY_VALUE, fetchUrl } from "../src/url";
+
+jest.mock(
+  "kolmafia",
+  () => ({
+    visitUrl: jest.fn(),
+  }),
+  { virtual: true }
+);
+
+describe(buildUrl, () => {
+  it.each([
+    "test.php",
+    "test.php?foo=bar",
+    "test.php?foo=bar&baz=qux",
+    "https://www.google.com/",
+  ])("should not modify a given path if there is no query", (path) => {
+    expect(buildUrl(path)).toEqual(path);
+  });
+
+  it.each([
+    ["test.php", { foo: "bar" }, "test.php?foo=bar"],
+    ["test.php", { foo: "bar", baz: "qux" }, "test.php?foo=bar&baz=qux"],
+    ["test.php?foo=bar", { baz: "qux" }, "test.php?foo=bar&baz=qux"],
+    [
+      "test.php",
+      { message: "Send me hugs & kisses", foo: "bar=baz" },
+      "test.php?message=Send%20me%20hugs%20%26%20kisses&foo=bar%3Dbaz",
+    ],
+    [
+      "test.php?foo=bar%3Dbaz",
+      { message: "Send me hugs & kisses" },
+      "test.php?foo=bar%3Dbaz&message=Send%20me%20hugs%20%26%20kisses",
+    ],
+  ])(
+    "should append query (as object) to the given path",
+    (path, query, expected) => {
+      expect(buildUrl(path, query)).toEqual(expected);
+    }
+  );
+
+  it.each([
+    ["test.php", [["foo", "bar"]], "test.php?foo=bar"],
+    [
+      "test.php",
+      [
+        ["foo", "bar"],
+        ["baz", "qux"],
+      ],
+      "test.php?foo=bar&baz=qux",
+    ],
+    ["test.php?foo=bar", [["baz", "qux"]], "test.php?foo=bar&baz=qux"],
+    [
+      "test.php",
+      [
+        ["message", "Send me hugs & kisses"],
+        ["foo", "bar=baz"],
+      ],
+      "test.php?message=Send%20me%20hugs%20%26%20kisses&foo=bar%3Dbaz",
+    ],
+    [
+      "test.php?foo=bar%3Dbaz",
+      [["message", "Send me hugs & kisses"]],
+      "test.php?foo=bar%3Dbaz&message=Send%20me%20hugs%20%26%20kisses",
+    ],
+  ] as const)(
+    "should append query (as array) to the given path",
+    (path, query, expected) => {
+      expect(buildUrl(path, query)).toEqual(expected);
+    }
+  );
+
+  it.each([
+    ["test.php?foo=bar", { foo: "baz" }, "test.php?foo=bar&foo=baz"],
+    [
+      "test.php?foo=bar%3Dbaz",
+      { foo: "bar&baz" },
+      "test.php?foo=bar%3Dbaz&foo=bar%26baz",
+    ],
+  ])(
+    "should append a parameter even if it already exists",
+    (path, query, expected) => {
+      expect(buildUrl(path, query)).toEqual(expected);
+    }
+  );
+
+  it.each([
+    [
+      "test.php",
+      { foo: 42, bar: true, baz: EMPTY_VALUE },
+      "test.php?foo=42&bar=true&baz",
+    ],
+    [
+      "test.php",
+      [
+        ["foo", true],
+        ["bar", EMPTY_VALUE],
+        ["baz", 11],
+      ],
+      "test.php?foo=true&bar&baz=11",
+    ],
+  ] as const)(
+    "should correctly encode non-string types",
+    (path, query, expected) => {
+      expect(buildUrl(path, query)).toEqual(expected);
+    }
+  );
+
+  it.each([
+    [["foo", "bar", "baz"]],
+    [[["foo", "bar"], ["baz"], ["quux", "quuz"]]],
+    [
+      [
+        ["foo", "bar"],
+        ["baz", "qux", "quux"],
+      ],
+    ],
+  ])("should fail if a query parameter is not a pair", (query) => {
+    expect(() => buildUrl("test.php", query as any)).toThrow(
+      "may only contain pair"
+    );
+  });
+});
+
+describe(fetchUrl, () => {
+  it("should call visitUrl with post=false and encoded=true", () => {
+    fetchUrl("test.php", { foo: "bar&baz" });
+
+    expect(visitUrl).toHaveBeenCalledWith("test.php?foo=bar%26baz", true, true);
+  });
+
+  it("should call visitUrl with post=false if requested", () => {
+    fetchUrl("test.php", { foo: "bar&baz" }, { method: "GET" });
+
+    expect(visitUrl).toHaveBeenCalledWith(
+      "test.php?foo=bar%26baz",
+      false,
+      true
+    );
+  });
+});
+
+describe(combineQuery, () => {
+  it("should return an empty query array if no queries are given", () => {
+    expect(combineQuery()).toEqual([]);
+  });
+
+  it("should return the given query if only one query is given", () => {
+    expect(combineQuery({ foo: "bar" })).toEqual({ foo: "bar" });
+  });
+
+  it("should combine multiple object queries into one", () => {
+    expect(combineQuery({ foo: "bar" }, { baz: "qux" })).toEqual([
+      ["foo", "bar"],
+      ["baz", "qux"],
+    ]);
+  });
+
+  it("should combine multiple array queries into one", () => {
+    expect(combineQuery([["foo", "bar"]], [["baz", "qux"]])).toEqual([
+      ["foo", "bar"],
+      ["baz", "qux"],
+    ]);
+  });
+
+  it("should combine an object and an array into one", () => {
+    expect(combineQuery({ foo: "bar" }, [["baz", "qux"]])).toEqual([
+      ["foo", "bar"],
+      ["baz", "qux"],
+    ]);
+  });
+
+  it("should combine an array and an object into one", () => {
+    expect(combineQuery([["foo", "bar"]], { baz: "qux" })).toEqual([
+      ["foo", "bar"],
+      ["baz", "qux"],
+    ]);
+  });
+
+  it("should combine more than two queries", () => {
+    expect(
+      combineQuery({ foo: "bar" }, [["baz", "qux"]], { quux: "quuz" })
+    ).toEqual([
+      ["foo", "bar"],
+      ["baz", "qux"],
+      ["quux", "quuz"],
+    ]);
+  });
+});

--- a/src/url.ts
+++ b/src/url.ts
@@ -1,0 +1,85 @@
+import { visitUrl } from "kolmafia";
+
+export const EMPTY_VALUE = Symbol("empty");
+type QValue = string | number | boolean | typeof EMPTY_VALUE;
+export type QueryList = readonly (readonly [key: string, value: QValue])[];
+export type QueryObject = Record<string, QValue>;
+export type Query = QueryList | QueryObject;
+
+type Options = {
+  method?: "GET" | "POST";
+};
+
+/**
+ * Fetches a URL and returns the response
+ * @param path Path to resource, e.g. "clan_basement.php"
+ * @param query Query parameters,
+ *  either as an object, e.g. { action: "cleansewer" },
+ *  or as a list of [key, value] pairs, e.g. [["action", "cleansewer"]]
+ * @param options Additional options
+ * @param options.method HTTP method to use, either "GET" or "POST", defaults to "POST"
+ * @returns the response from visiting the URL
+ */
+export function fetchUrl(
+  path: string,
+  query: Query = [],
+  options: Options = {}
+): string {
+  const { method = "POST" } = options;
+
+  const url = buildUrl(path, query);
+
+  return visitUrl(url, method === "POST", true);
+}
+
+/**
+ * Builds a URL from a path and query
+ * @param path Path to resource, e.g. "clan_basement.php"
+ * @param query Query parameters,
+ *  either as an object, e.g. { action: "cleansewer" },
+ *  or as a list of [key, value] pairs, e.g. [["action", "cleansewer"]]
+ * @returns the constructed URL, e.g. "clan_basement.php?action=cleansewer"
+ */
+export function buildUrl(path: string, query: Query = []): string {
+  const urlParams = Array.isArray(query) ? query : Object.entries(query);
+  if (urlParams.length === 0) {
+    return path;
+  }
+
+  const chunks = [path];
+  let sep = path.includes("?") ? "&" : "?";
+  for (const param of urlParams) {
+    if (param.length !== 2) {
+      throw new Error(`Query parameter array may only contain pair elements`);
+    }
+    const [key, value] = param;
+    chunks.push(sep);
+    sep = "&";
+    chunks.push(encodeURIComponent(key));
+    if (value !== EMPTY_VALUE) {
+      chunks.push("=");
+      chunks.push(encodeURIComponent(value));
+    }
+  }
+  return chunks.join("");
+}
+
+/**
+ * Combines a list of queries into a single query
+ * @param queries a list of query objects and/or arrays, can be mixed
+ * @returns a single query
+ */
+export function combineQuery(...queries: Query[]): Query {
+  if (queries.length === 1) {
+    return queries[0];
+  }
+  const result = [];
+  for (const query of queries) {
+    if (Array.isArray(query)) {
+      result.push(...query);
+    } else {
+      result.push(...Object.entries(query));
+    }
+  }
+  return result;
+}


### PR DESCRIPTION
This is an attempt to Fix #505 

I've added a fetchUrl method that takes a path and a query parameter, and makes sure the parameters are properly encoded.

Using this method outside of KMail is not in the scope of this PR, but would probably be useful also in other places.

I'm happy to change the naming, if somebody can come up with a better suggestion.

To make sure I don't break anything, I've added a test suite for KMail.send and KMail.gift. The fetchUrl-change causes slight changes in the generated URLs, but this is expected and in fact desired. The changes applied to the test file in the second commit sound sensible to me, but please someone double check.