### PR TITLE
feat: improve lookup results for players that don't exist

### DIFF
--- a/__tests__/__mocks__/kolmafia.ts
+++ b/__tests__/__mocks__/kolmafia.ts
@@ -163,6 +163,9 @@ export class Vykea extends MafiaClass {
   static none = {};
 }
 
+export const getPlayerName = jest.fn();
+export const getPlayerId = jest.fn();
+
 export const getProperty = jest.fn();
 
 export const isGiftable = jest.fn();

--- a/__tests__/lib/player-lookup.ts
+++ b/__tests__/lib/player-lookup.ts
@@ -1,0 +1,192 @@
+import { mocked } from "jest-mock";
+import { getPlayerId, getPlayerName } from "kolmafia";
+
+import {
+  getPlayerFromIdOrName,
+  getPlayerIdFromName,
+  getPlayerNameFromId,
+} from "../../src";
+
+jest.mock("kolmafia");
+
+mocked(getPlayerName).mockImplementation((id: number) => {
+  switch (id) {
+    case 1:
+      return "Jick";
+    case 1889009:
+      return "Buffy";
+    default:
+      return id.toString();
+  }
+});
+mocked(getPlayerId).mockImplementation((name: string) => {
+  switch (name.toLowerCase()) {
+    case "jick":
+      return "1";
+    case "buffy":
+      return "1889009";
+    default:
+      return name;
+  }
+});
+
+describe(getPlayerIdFromName, () => {
+  describe("with onMissing = 'throw'", () => {
+    it.each([
+      ["Jick", 1],
+      ["Buffy", 1889009],
+    ])("should return the player id for a given name", (name, id) => {
+      expect(getPlayerIdFromName(name)).toBe(id);
+    });
+
+    it.each([
+      ["jick", 1],
+      ["JICK", 1],
+      ["bufFy", 1889009],
+      ["BuffY", 1889009],
+    ])(
+      "should return the player id for a given name, case-insensitively",
+      (name, id) => {
+        expect(getPlayerIdFromName(name)).toBe(id);
+      }
+    );
+
+    it("should throw an error for an unknown name", () => {
+      expect(() => getPlayerIdFromName("Unknown")).toThrowError(
+        "Player not found: Unknown"
+      );
+    });
+  });
+
+  describe("with onMissing = 'return-null'", () => {
+    it.each([
+      ["Jick", 1],
+      ["Buffy", 1889009],
+    ])("should return the player id for a given name", (name, id) => {
+      expect(getPlayerIdFromName(name, "return-null")).toBe(id);
+    });
+
+    it.each([
+      ["jick", 1],
+      ["JICK", 1],
+      ["bufFy", 1889009],
+      ["BuffY", 1889009],
+    ])(
+      "should return the player id for a given name, case-insensitively",
+      (name, id) => {
+        expect(getPlayerIdFromName(name, "return-null")).toBe(id);
+      }
+    );
+
+    it("should return undefined for an unknown name", () => {
+      expect(getPlayerIdFromName("Unknown", "return-null")).toBeNull();
+    });
+  });
+});
+
+describe(getPlayerNameFromId, () => {
+  describe("with onMissing = 'throw'", () => {
+    it.each([
+      [1, "Jick"],
+      [1889009, "Buffy"],
+    ])("should return the player name for a given id", (id, name) => {
+      expect(getPlayerNameFromId(id)).toBe(name);
+    });
+
+    it("should throw an error for an unknown id", () => {
+      expect(() => getPlayerNameFromId(123)).toThrowError(
+        "Player not found: 123"
+      );
+    });
+  });
+
+  describe("with onMissing = 'return-null'", () => {
+    it.each([
+      [1, "Jick"],
+      [1889009, "Buffy"],
+    ])("should return the player name for a given id", (id, name) => {
+      expect(getPlayerNameFromId(id, "return-null")).toBe(name);
+    });
+
+    it("should return undefined for an unknown id", () => {
+      expect(getPlayerNameFromId(123, "return-null")).toBeNull();
+    });
+  });
+});
+
+describe(getPlayerFromIdOrName, () => {
+  describe("with onMissing = 'throw'", () => {
+    it.each([
+      [1, "Jick"],
+      [1889009, "Buffy"],
+    ])("should return the player id and name for a given id", (id, name) => {
+      expect(getPlayerFromIdOrName(id)).toEqual({ id, name });
+    });
+
+    it.each([
+      ["Jick", 1],
+      ["Buffy", 1889009],
+    ])("should return the player id and name for a given name", (name, id) => {
+      expect(getPlayerFromIdOrName(name)).toEqual({ id, name });
+    });
+
+    it.each([
+      ["jick", 1, "Jick"],
+      ["JICK", 1, "Jick"],
+      ["bufFy", 1889009, "Buffy"],
+      ["BuffY", 1889009, "Buffy"],
+    ])(
+      "should return the player id and name for a given name, case-insensitively",
+      (name, id, expectedName) => {
+        expect(getPlayerFromIdOrName(name)).toEqual({ id, name: expectedName });
+      }
+    );
+
+    it.each(["Unknown", 123])(
+      "should throw an error for an unknown id or name",
+      (idOrName) => {
+        expect(() => getPlayerFromIdOrName(idOrName)).toThrowError(
+          `Player not found: ${idOrName}`
+        );
+      }
+    );
+  });
+
+  describe("with onMissing = 'return-null'", () => {
+    it.each([
+      [1, "Jick"],
+      [1889009, "Buffy"],
+    ])("should return the player id and name for a given id", (id, name) => {
+      expect(getPlayerFromIdOrName(id, "return-null")).toEqual({ id, name });
+    });
+
+    it.each([
+      ["Jick", 1],
+      ["Buffy", 1889009],
+    ])("should return the player id and name for a given name", (name, id) => {
+      expect(getPlayerFromIdOrName(name, "return-null")).toEqual({ id, name });
+    });
+
+    it.each([
+      ["jick", 1, "Jick"],
+      ["JICK", 1, "Jick"],
+      ["bufFy", 1889009, "Buffy"],
+      ["BuffY", 1889009, "Buffy"],
+    ])(
+      "should return the player id and name for a given name, case-insensitively",
+      (name, id, expectedName) => {
+        expect(getPlayerFromIdOrName(name, "return-null")).toEqual({
+          id,
+          name: expectedName,
+        });
+      }
+    );
+
+    it.each(["Unknown", 123])(
+      "should return undefined for an unknown id or name",
+      (idOrName) => {
+        expect(getPlayerFromIdOrName(idOrName, "return-null")).toBeNull();
+      }
+    );
+  });
+});

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -586,6 +586,82 @@ export function uneffect(effect: Effect): boolean {
   return cliExecute(`uneffect ${effect.name}`);
 }
 
+/**
+ * Get the player id from a player name
+ * @param name the name of the player
+ * @param onMissing Pass "throw" or omit to throw an error if the player is not found
+ * @returns the player id, or throws if no such player exists
+ */
+export function getPlayerIdFromName(name: string, onMissing?: "throw"): number;
+/**
+ * Get the player id from a player name (if it exists)
+ * @param name the name of the player
+ * @param onMissing Pass "throw" to throw an error if the player is not found, or "return-null" to return null
+ * @returns the player id if the player exists, or handles according to onMissing
+ */
+export function getPlayerIdFromName(
+  name: string,
+  onMissing: "throw" | "return-null"
+): number | null;
+/**
+ * Get the player id from a player name (if it exists)
+ * @param name the name of the player
+ * @param onMissing Pass "throw" to throw an error if the player is not found, or "return-null" to return null
+ * @returns the player id if the player exists, or handles according to onMissing
+ */
+export function getPlayerIdFromName(
+  name: string,
+  onMissing: "throw" | "return-null" = "throw"
+): number | null {
+  const playerId = getPlayerId(name);
+  // KoLmafia returns the input when not found
+  if (playerId === name) {
+    if (onMissing === "throw") {
+      throw new Error(`Player not found: ${name}`);
+    }
+    return null;
+  }
+  return parseInt(playerId);
+}
+
+/**
+ * Get the player id from a player name
+ * @param id the id of the player
+ * @param onMissing Pass "throw" or omit to throw an error if the player is not found
+ * @returns the player id, or throws if no such player exists
+ */
+export function getPlayerNameFromId(id: number, onMissing?: "throw"): string;
+/**
+ * Get the player id from a player name (if it exists)
+ * @param id the id of the player
+ * @param onMissing Pass "throw" to throw an error if the player is not found, or "return-null" to return null * @returns the player id, or null if no such player exists
+ * @returns the player id if the player exists, or handles according to onMissing
+ */
+export function getPlayerNameFromId(
+  id: number,
+  onMissing: "throw" | "return-null"
+): string | null;
+/**
+ * Get the player id from a player name (if it exists)
+ * @param id the id of the player
+ * @param onMissing Pass "throw" to throw an error if the player is not found, or "return-null" to return null
+ * @returns the player id if the player exists, or handles according to onMissing
+ */
+export function getPlayerNameFromId(
+  id: number,
+  onMissing: "throw" | "return-null" = "throw"
+): string | null {
+  const playerName = getPlayerName(id);
+  // KoLmafia returns the input when not found
+  if (playerName === id.toString()) {
+    if (onMissing === "throw") {
+      throw new Error(`Player not found: ${playerName}`);
+    }
+    return null;
+  }
+  return playerName;
+}
+
 export type Player = {
   name: string;
   id: number;
@@ -595,15 +671,47 @@ export type Player = {
  * Get both the name and id of a player from either their name or id
  *
  * @param idOrName Id or name of player
+ * @param onMissing Pass "throw" or omit to throw an error if the player is not found
  * @returns Object containing id and name of player
+ * @throws {Error} Throws an error if the player is not found
  */
-export function getPlayerFromIdOrName(idOrName: number | string): Player {
-  const id =
-    typeof idOrName === "number" ? idOrName : parseInt(getPlayerId(idOrName));
-  return {
-    name: getPlayerName(id),
-    id: id,
-  };
+export function getPlayerFromIdOrName(
+  idOrName: number | string,
+  onMissing?: "throw"
+): Player;
+/**
+ * Get both the name and id of a player from either their name or id
+ *
+ * @param idOrName Id or name of player
+ * @param onMissing Pass "return-null" to return null if the player is not found
+ * @returns Object containing id and name of player if it exists, or handles according to onMissing
+ */
+export function getPlayerFromIdOrName(
+  idOrName: number | string,
+  onMissing: "throw" | "return-null"
+): Player | null;
+/**
+ * Get both the name and id of a player from either their name or id
+ *
+ * @param idOrName Id or name of player
+ * @param onMissing Pass "throw" to throw an error if the player is not found, or "return-null" to return null
+ * @returns Object containing id and name of player if it exists, or handles according to onMissing
+ */
+export function getPlayerFromIdOrName(
+  idOrName: number | string,
+  onMissing: "throw" | "return-null" = "throw"
+): Player | null {
+  if (typeof idOrName === "number") {
+    const name = getPlayerNameFromId(idOrName, onMissing);
+    if (name === null) return null;
+    return { name, id: idOrName };
+  } else {
+    const id = getPlayerIdFromName(idOrName, onMissing);
+    if (id === null) return null;
+    // load from KoLmafia to get the right capitalization
+    const name = getPlayerName(id);
+    return { name, id };
+  }
 }
 
 /**


### PR DESCRIPTION
KoLmafia getPlayerId/getPlayerName simply return the input string if a player does not exist. This leads to strange behaviour in getPlayerFromIdOrName where it returns `{name:0, id: null}` or `{name:"<id>", id: <id>}`. This is very inconvenient to handle, especially if the code expects that a user might not exist (because it's handling user input for example).

Solve by adding getPlayerIdFromName and getPlayerNameFromId that can be configured to either throw an error or return null if the player does not exist.
Add the same parameter to getPlayerFromIdOrName, defaulting to throw an exception, in order not to break signature compatibility with existing code.

Please note that most often the input name or id will have come from KoLmafia, so it's quite certain that the player exists. Forcing every caller to handle null values would IMHO be inappropriate.
