### PR TITLE
Improve/fix Kmail parsing

### DIFF
--- a/__tests__/Kmail.ts
+++ b/__tests__/Kmail.ts
@@ -372,7 +372,7 @@ describe("message parsing", () => {
           "<center><table><tr><td><img src=\"https://d2uyhvukfffg5a.cloudfront.net/adventureimages/1335.gif\" width=100 height=100></td><td valign=center>r0535 R R3d<br>5ug4r i5 5w337<br>If U'd b3 m1n3<br>I'd f33l pr377y 1337.</td></tr></table></center>This is a valentine's message with &lt;b&gt;fake html&lt;/b&gt;\r\n\r\n",
       },
       expectedMessage:
-        "This is a valentine's message with &lt;b&gt;fake html&lt;/b&gt;\r\n\r\n",
+        "This is a valentine's message with <b>fake html</b>\r\n\r\n",
       expectedMeat: 0,
     },
   ])(
@@ -396,11 +396,9 @@ describe("message parsing", () => {
           'This is an outside note with &lt;fake&gt;&lt;/html&gt;<center><table class="item" style="float: none" rel="id=1167&s=0&q=0&d=0&g=1&t=0&n=1&m=0&p=0&u=."><tr><td><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/plainbrown.gif" alt="plain brown wrapper" title="plain brown wrapper" class=hand onClick=\'descitem(546961999)\' ></td><td valign=center class=effect>You acquire an item: <b>plain brown wrapper</b></td></tr></table></center><p>Inside Note:<p>This is an inside note with &lt;b&gt;fake&lt;/b&gt;&lt;/html&gt;<center><table><tr><td><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/meat.gif" height=30 width=30 alt="Meat"></td><td valign=center>You gain 11 Meat.</td></tr></table></center><center><table class="item" style="float: none" rel="id=4508&s=0&q=0&d=0&g=0&t=1&n=1&m=1&p=0&u=u"><tr><td><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/drinkme.gif" alt="&quot;DRINK ME&quot; potion" title="&quot;DRINK ME&quot; potion" class=hand onClick=\'descitem(830929931)\' ></td><td valign=center class=effect>You acquire an item: <b>&quot;DRINK ME&quot; potion</b></td></tr></table></center>',
       },
       expectedMessage:
-        "This is an outside note with &lt;fake&gt;&lt;/html&gt;\n\nInside Note:\nThis is an inside note with &lt;b&gt;fake&lt;/b&gt;&lt;/html&gt;",
-      expectedOutsideNote:
-        "This is an outside note with &lt;fake&gt;&lt;/html&gt;",
-      expectedInsideNote:
-        "This is an inside note with &lt;b&gt;fake&lt;/b&gt;&lt;/html&gt;",
+        "This is an outside note with <fake></html>\n\nInside Note:\nThis is an inside note with <b>fake</b></html>",
+      expectedOutsideNote: "This is an outside note with <fake></html>",
+      expectedInsideNote: "This is an inside note with <b>fake</b></html>",
       expectedItems: new Map([
         [$item`plain brown wrapper`, 1],
         [$item`"DRINK ME" potion`, 1],
@@ -417,10 +415,8 @@ describe("message parsing", () => {
         message:
           'This is an outside note with &lt;b&gt;fake html&lt;/b&gt;.<center><table class="item" style="float: none" rel="id=1168&s=0&q=0&d=0&g=1&t=0&n=1&m=0&p=0&u=."><tr><td><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/lessthan3.gif" alt="less-than-three-shaped box" title="less-than-three-shaped box" class=hand onClick=\'descitem(938194457)\' ></td><td valign=center class=effect>You acquire an item: <b>less-than-three-shaped box</b></td></tr></table></center>',
       },
-      expectedMessage:
-        "This is an outside note with &lt;b&gt;fake html&lt;/b&gt;.",
-      expectedOutsideNote:
-        "This is an outside note with &lt;b&gt;fake html&lt;/b&gt;.",
+      expectedMessage: "This is an outside note with <b>fake html</b>.",
+      expectedOutsideNote: "This is an outside note with <b>fake html</b>.",
       expectedInsideNote: null,
       expectedItems: new Map([[$item`less-than-three-shaped box`, 1]]),
       expectedOutsideItems: new Map([[$item`less-than-three-shaped box`, 1]]),
@@ -436,11 +432,9 @@ describe("message parsing", () => {
           'This is an outside note with &lt;b&gt;fake html&lt;/b&gt;.<center><table class="item" style="float: none" rel="id=1168&s=0&q=0&d=0&g=1&t=0&n=1&m=0&p=0&u=."><tr><td><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/lessthan3.gif" alt="less-than-three-shaped box" title="less-than-three-shaped box" class=hand onClick=\'descitem(938194457)\' ></td><td valign=center class=effect>You acquire an item: <b>less-than-three-shaped box</b></td></tr></table></center><p>Inside Note:<p>This is an inside note with &lt;b&gt;fake html&lt;/b&gt;.<center><table class="item" style="float: none" rel="id=4508&s=0&q=0&d=0&g=0&t=1&n=11&m=1&p=0&u=u"><tr><td><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/drinkme.gif" alt="&quot;DRINK ME&quot; potion" title="&quot;DRINK ME&quot; potion" class=hand onClick=\'descitem(830929931)\' ></td><td valign=center class=effect>You acquire <b>11 bottles of &quot;DRINK ME&quot; potion</b><br>(That\'s ridiculous.  It\'s not even funny.)</td></tr></table></center><center><table class="item" style="float: none" rel="id=1907&s=65&q=0&d=1&g=0&t=1&n=1&m=0&p=0&u=u"><tr><td><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/8ball.gif" alt="8-ball" title="8-ball" class=hand onClick=\'descitem(631597539)\' ></td><td valign=center class=effect>You acquire an item: <b>8-ball</b></td></tr></table></center>',
       },
       expectedMessage:
-        "This is an outside note with &lt;b&gt;fake html&lt;/b&gt;.\n\nInside Note:\nThis is an inside note with &lt;b&gt;fake html&lt;/b&gt;.",
-      expectedOutsideNote:
-        "This is an outside note with &lt;b&gt;fake html&lt;/b&gt;.",
-      expectedInsideNote:
-        "This is an inside note with &lt;b&gt;fake html&lt;/b&gt;.",
+        "This is an outside note with <b>fake html</b>.\n\nInside Note:\nThis is an inside note with <b>fake html</b>.",
+      expectedOutsideNote: "This is an outside note with <b>fake html</b>.",
+      expectedInsideNote: "This is an inside note with <b>fake html</b>.",
       expectedItems: new Map([
         [$item`less-than-three-shaped box`, 1],
         [$item`"DRINK ME" potion`, 11],

--- a/__tests__/Kmail.ts
+++ b/__tests__/Kmail.ts
@@ -208,6 +208,30 @@ describe("message parsing", () => {
     localtime: "04/25/24 09:11:44 PM",
   };
 
+  it("should parse the same time from azunixtime and localtime", () => {
+    mocked(visitUrl).mockReturnValueOnce(
+      JSON.stringify([
+        { ...baseMessage, type: "normal", message: "Hello, world!" },
+      ])
+    );
+
+    const kmails = Kmail.inbox();
+    expect(kmails).toHaveLength(1);
+    expect(
+      kmails[0].date
+        .toLocaleString("en-US", {
+          day: "2-digit",
+          month: "2-digit",
+          year: "2-digit",
+          hour: "2-digit",
+          minute: "2-digit",
+          second: "2-digit",
+          hour12: true,
+        })
+        .replace(/, /g, " ")
+    ).toEqual(baseMessage.localtime);
+  });
+
   it.each([
     {
       input: {

--- a/__tests__/Kmail.ts
+++ b/__tests__/Kmail.ts
@@ -1,6 +1,5 @@
 import { isGiftable, Item, visitUrl } from "kolmafia";
 import { $item, Kmail } from "../src";
-
 import mocked = jest.mocked;
 
 jest.mock("kolmafia");
@@ -195,4 +194,280 @@ describe(Kmail.gift, () => {
       true
     );
   });
+});
+
+describe("message parsing", () => {
+  // we need the correct plural for the extractItems mock to work
+  ($item`"DRINK ME" potion` as any).plural = `bottles of "DRINK ME" potion`;
+
+  const baseMessage = {
+    id: "11",
+    fromid: "1852283",
+    fromname: "StuBorn",
+    azunixtime: "1714072304",
+    localtime: "04/25/24 09:11:44 PM",
+  };
+
+  it.each([
+    {
+      input: {
+        // fake meat gain in message
+        ...baseMessage,
+        type: "normal",
+        message: "You gain 11 Meat.",
+      },
+      expectedMeat: 0,
+    },
+    {
+      input: {
+        // fake meat gain in message with different suffix
+        ...baseMessage,
+        type: "normal",
+        message: "You gain 11 Meatballs",
+      },
+      expectedMeat: 0,
+    },
+    {
+      input: {
+        // fake html of meat gain in message
+        ...baseMessage,
+        type: "normal",
+        message:
+          "&lt;center&gt;&lt;table&gt;&lt;tr&gt;&lt;td&gt;&lt;img src=&quot;https://d2uyhvukfffg5a.cloudfront.net/itemimages/meat.gif&quot; height=30 width=30 alt=&quot;Meat&quot;&gt;&lt;/td&gt;&lt;td valign=center&gt;You gain 11 Meat.&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/center&gt;",
+      },
+      expectedMeat: 0,
+    },
+    {
+      input: {
+        // fake meat gain in message while actually sending less real meat
+        ...baseMessage,
+        type: "normal",
+        message:
+          'You gain 11 Meat.<center><table><tr><td><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/meat.gif" height=30 width=30 alt="Meat"></td><td valign=center>You gain 1 Meat.</td></tr></table></center>',
+      },
+      expectedMeat: 1,
+    },
+    {
+      input: {
+        // fake meat gain in outside message of gift (unopened)
+        ...baseMessage,
+        type: "giftshop",
+        message:
+          'You gain 11 Meat.<center><table class="item" style="float: none" rel="id=1167&s=0&q=0&d=0&g=1&t=0&n=1&m=0&p=0&u=."><tr><td><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/plainbrown.gif" alt="plain brown wrapper" title="plain brown wrapper" class=hand onClick=\'descitem(546961999)\' ></td><td valign=center class=effect>You acquire an item: <b>plain brown wrapper</b></td></tr></table></center>',
+      },
+      expectedMeat: 0,
+    },
+    {
+      input: {
+        // fake meat gain in outside and inside message of gift while actually sending less real meat
+        ...baseMessage,
+        type: "giftshop",
+        message:
+          'You gain 11 Meat.<center><table class="item" style="float: none" rel="id=1167&s=0&q=0&d=0&g=1&t=0&n=1&m=0&p=0&u=."><tr><td><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/plainbrown.gif" alt="plain brown wrapper" title="plain brown wrapper" class=hand onClick=\'descitem(546961999)\' ></td><td valign=center class=effect>You acquire an item: <b>plain brown wrapper</b></td></tr></table></center><p>Inside Note:<p>You gain 11 Meat.<center><table><tr><td><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/meat.gif" height=30 width=30 alt="Meat"></td><td valign=center>You gain 1 Meat.</td></tr></table></center>',
+      },
+      expectedMeat: 1,
+    },
+    {
+      input: {
+        // fake meat gain in message with valentine
+        ...baseMessage,
+        type: "normal",
+        message:
+          '<center><table><tr><td><img src="https://d2uyhvukfffg5a.cloudfront.net/adventureimages/1335.gif" width=100 height=100></td><td valign=center>r0535 R R3d<br>5ug4r i5 5w337<br>If U\'d b3 m1n3<br>I\'d f33l pr377y 1337.</td></tr></table></center>You gain 11 Meat.<center><table><tr><td><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/meat.gif" height=30 width=30 alt="Meat"></td><td valign=center>You gain 1 Meat.</td></tr></table></center>',
+      },
+      expectedMeat: 1,
+    },
+    {
+      input: {
+        // fake meat gain in message with valentine while actually sending less real meat
+        ...baseMessage,
+        type: "normal",
+        message:
+          "<center><table><tr><td><img src=\"https://d2uyhvukfffg5a.cloudfront.net/adventureimages/1335.gif\" width=100 height=100></td><td valign=center>r0535 R R3d<br>5ug4r i5 5w337<br>If U'd b3 m1n3<br>I'd f33l pr377y 1337.</td></tr></table></center>You gain 11 Meat.",
+      },
+      expectedMeat: 0,
+    },
+  ] as const)(
+    "should not be fooled with fake meat gains",
+    ({ input, expectedMeat }) => {
+      mocked(visitUrl).mockReturnValueOnce(JSON.stringify([input]));
+
+      const kmails = Kmail.inbox();
+      expect(kmails).toHaveLength(1);
+      expect(kmails[0].message).toMatch("You gain 11 Meat");
+      expect(kmails[0].meat()).toEqual(expectedMeat);
+    }
+  );
+
+  it.each([
+    {
+      input: {
+        ...baseMessage,
+        type: "normal",
+        message:
+          'You acquire an item: &lt;b&gt;Mr. Accessory&lt;/b&gt;<center><table class="item" style="float: none" rel="id=4508&s=0&q=0&d=0&g=0&t=1&n=1&m=1&p=0&u=u"><tr><td><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/drinkme.gif" alt="&quot;DRINK ME&quot; potion" title="&quot;DRINK ME&quot; potion" class=hand onClick=\'descitem(830929931)\' ></td><td valign=center class=effect>You acquire an item: <b>&quot;DRINK ME&quot; potion</b></td></tr></table></center>',
+      },
+      expectedItems: new Map([[$item`"DRINK ME" potion`, 1]]),
+    },
+    {
+      input: {
+        ...baseMessage,
+        type: "normal",
+        message:
+          'You acquire an item: &lt;b&gt;Mr. Accessory&lt;/b&gt;\r\n<center><table class="item" style="float: none" rel="id=4508&s=0&q=0&d=0&g=0&t=1&n=11&m=1&p=0&u=u"><tr><td><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/drinkme.gif" alt="&quot;DRINK ME&quot; potion" title="&quot;DRINK ME&quot; potion" class=hand onClick=\'descitem(830929931)\' ></td><td valign=center class=effect>You acquire <b>11 bottles of &quot;DRINK ME&quot; potion</b><br>(That\'s ridiculous.  It\'s not even funny.)</td></tr></table></center>',
+      },
+      expectedItems: new Map([[$item`"DRINK ME" potion`, 11]]),
+    },
+  ])(
+    "should not be fooled by fake item gains in a message",
+    ({ input, expectedItems }) => {
+      mocked(visitUrl).mockReturnValueOnce(JSON.stringify([input]));
+
+      const kmails = Kmail.inbox();
+      expect(kmails).toHaveLength(1);
+      expect(kmails[0].items()).toEqual(expectedItems);
+    }
+  );
+
+  it.each([
+    {
+      input: {
+        ...baseMessage,
+        type: "normal",
+        message:
+          '<center><table><tr><td><img src="https://d2uyhvukfffg5a.cloudfront.net/adventureimages/smiley.gif" width=100 height=100></td><td valign=center>You zerg rush\'d my heart<br>Your love gets me high<br>Come give me a kiss<br>You\'re oh em gee KAWAIIIIIIII!!11!!11!!!?!!?!</td></tr></table></center>This is a message<center><table class="item" style="float: none" rel="id=4508&s=0&q=0&d=0&g=0&t=1&n=1&m=1&p=0&u=u"><tr><td><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/drinkme.gif" alt="&quot;DRINK ME&quot; potion" title="&quot;DRINK ME&quot; potion" class=hand onClick=\'descitem(830929931)\' ></td><td valign=center class=effect>You acquire an item: <b>&quot;DRINK ME&quot; potion</b></td></tr></table></center><center><table><tr><td><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/meat.gif" height=30 width=30 alt="Meat"></td><td valign=center>You gain 11 Meat.</td></tr></table></center>',
+      },
+      expectedMessage: "This is a message",
+      expectedMeat: 11,
+    },
+    {
+      input: {
+        ...baseMessage,
+        type: "normal",
+        message:
+          "<center><table><tr><td><img src=\"https://d2uyhvukfffg5a.cloudfront.net/adventureimages/1335.gif\" width=100 height=100></td><td valign=center>r0535 R R3d<br>5ug4r i5 5w337<br>If U'd b3 m1n3<br>I'd f33l pr377y 1337.</td></tr></table></center>This is a valentine's message with &lt;b&gt;fake html&lt;/b&gt;\r\n\r\n",
+      },
+      expectedMessage:
+        "This is a valentine's message with &lt;b&gt;fake html&lt;/b&gt;\r\n\r\n",
+      expectedMeat: 0,
+    },
+  ])(
+    "should strip off valentine messages",
+    ({ input, expectedMessage, expectedMeat }) => {
+      mocked(visitUrl).mockReturnValueOnce(JSON.stringify([input]));
+
+      const kmails = Kmail.inbox();
+      expect(kmails).toHaveLength(1);
+      expect(kmails[0].message).toEqual(expectedMessage);
+      expect(kmails[0].meat()).toEqual(expectedMeat);
+    }
+  );
+
+  it.each([
+    {
+      input: {
+        ...baseMessage,
+        type: "giftshop",
+        message:
+          'This is an outside note with &lt;fake&gt;&lt;/html&gt;<center><table class="item" style="float: none" rel="id=1167&s=0&q=0&d=0&g=1&t=0&n=1&m=0&p=0&u=."><tr><td><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/plainbrown.gif" alt="plain brown wrapper" title="plain brown wrapper" class=hand onClick=\'descitem(546961999)\' ></td><td valign=center class=effect>You acquire an item: <b>plain brown wrapper</b></td></tr></table></center><p>Inside Note:<p>This is an inside note with &lt;b&gt;fake&lt;/b&gt;&lt;/html&gt;<center><table><tr><td><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/meat.gif" height=30 width=30 alt="Meat"></td><td valign=center>You gain 11 Meat.</td></tr></table></center><center><table class="item" style="float: none" rel="id=4508&s=0&q=0&d=0&g=0&t=1&n=1&m=1&p=0&u=u"><tr><td><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/drinkme.gif" alt="&quot;DRINK ME&quot; potion" title="&quot;DRINK ME&quot; potion" class=hand onClick=\'descitem(830929931)\' ></td><td valign=center class=effect>You acquire an item: <b>&quot;DRINK ME&quot; potion</b></td></tr></table></center>',
+      },
+      expectedMessage:
+        "This is an outside note with &lt;fake&gt;&lt;/html&gt;\n\nInside Note:\nThis is an inside note with &lt;b&gt;fake&lt;/b&gt;&lt;/html&gt;",
+      expectedOutsideNote:
+        "This is an outside note with &lt;fake&gt;&lt;/html&gt;",
+      expectedInsideNote:
+        "This is an inside note with &lt;b&gt;fake&lt;/b&gt;&lt;/html&gt;",
+      expectedItems: new Map([
+        [$item`plain brown wrapper`, 1],
+        [$item`"DRINK ME" potion`, 1],
+      ]),
+      expectedOutsideItems: new Map([[$item`plain brown wrapper`, 1]]),
+      expectedInsideItems: new Map([[$item`"DRINK ME" potion`, 1]]),
+      expectedMeat: 11,
+    },
+    {
+      // unopened
+      input: {
+        ...baseMessage,
+        type: "giftshop",
+        message:
+          'This is an outside note with &lt;b&gt;fake html&lt;/b&gt;.<center><table class="item" style="float: none" rel="id=1168&s=0&q=0&d=0&g=1&t=0&n=1&m=0&p=0&u=."><tr><td><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/lessthan3.gif" alt="less-than-three-shaped box" title="less-than-three-shaped box" class=hand onClick=\'descitem(938194457)\' ></td><td valign=center class=effect>You acquire an item: <b>less-than-three-shaped box</b></td></tr></table></center>',
+      },
+      expectedMessage:
+        "This is an outside note with &lt;b&gt;fake html&lt;/b&gt;.",
+      expectedOutsideNote:
+        "This is an outside note with &lt;b&gt;fake html&lt;/b&gt;.",
+      expectedInsideNote: null,
+      expectedItems: new Map([[$item`less-than-three-shaped box`, 1]]),
+      expectedOutsideItems: new Map([[$item`less-than-three-shaped box`, 1]]),
+      expectedInsideItems: new Map(),
+      expectedMeat: 0,
+    },
+    {
+      // opened
+      input: {
+        ...baseMessage,
+        type: "giftshop",
+        message:
+          'This is an outside note with &lt;b&gt;fake html&lt;/b&gt;.<center><table class="item" style="float: none" rel="id=1168&s=0&q=0&d=0&g=1&t=0&n=1&m=0&p=0&u=."><tr><td><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/lessthan3.gif" alt="less-than-three-shaped box" title="less-than-three-shaped box" class=hand onClick=\'descitem(938194457)\' ></td><td valign=center class=effect>You acquire an item: <b>less-than-three-shaped box</b></td></tr></table></center><p>Inside Note:<p>This is an inside note with &lt;b&gt;fake html&lt;/b&gt;.<center><table class="item" style="float: none" rel="id=4508&s=0&q=0&d=0&g=0&t=1&n=11&m=1&p=0&u=u"><tr><td><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/drinkme.gif" alt="&quot;DRINK ME&quot; potion" title="&quot;DRINK ME&quot; potion" class=hand onClick=\'descitem(830929931)\' ></td><td valign=center class=effect>You acquire <b>11 bottles of &quot;DRINK ME&quot; potion</b><br>(That\'s ridiculous.  It\'s not even funny.)</td></tr></table></center><center><table class="item" style="float: none" rel="id=1907&s=65&q=0&d=1&g=0&t=1&n=1&m=0&p=0&u=u"><tr><td><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/8ball.gif" alt="8-ball" title="8-ball" class=hand onClick=\'descitem(631597539)\' ></td><td valign=center class=effect>You acquire an item: <b>8-ball</b></td></tr></table></center>',
+      },
+      expectedMessage:
+        "This is an outside note with &lt;b&gt;fake html&lt;/b&gt;.\n\nInside Note:\nThis is an inside note with &lt;b&gt;fake html&lt;/b&gt;.",
+      expectedOutsideNote:
+        "This is an outside note with &lt;b&gt;fake html&lt;/b&gt;.",
+      expectedInsideNote:
+        "This is an inside note with &lt;b&gt;fake html&lt;/b&gt;.",
+      expectedItems: new Map([
+        [$item`less-than-three-shaped box`, 1],
+        [$item`"DRINK ME" potion`, 11],
+        [$item`8-ball`, 1],
+      ]),
+      expectedOutsideItems: new Map([[$item`less-than-three-shaped box`, 1]]),
+      expectedInsideItems: new Map([
+        [$item`"DRINK ME" potion`, 11],
+        [$item`8-ball`, 1],
+      ]),
+      expectedMeat: 0,
+    },
+    {
+      input: {
+        ...baseMessage,
+        type: "giftshop",
+        message:
+          'This is a gift with an empty inside note<center><table class="item" style="float: none" rel="id=1167&s=0&q=0&d=0&g=1&t=0&n=1&m=0&p=0&u=."><tr><td><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/plainbrown.gif" alt="plain brown wrapper" title="plain brown wrapper" class=hand onClick=\'descitem(546961999)\' ></td><td valign=center class=effect>You acquire an item: <b>plain brown wrapper</b></td></tr></table></center><p>Inside Note:<p><center><table><tr><td><img src="https://d2uyhvukfffg5a.cloudfront.net/itemimages/meat.gif" height=30 width=30 alt="Meat"></td><td valign=center>You gain 1 Meat.</td></tr></table></center>',
+      },
+      expectedMessage:
+        "This is a gift with an empty inside note\n\nInside Note:\n",
+      expectedOutsideNote: "This is a gift with an empty inside note",
+      expectedInsideNote: "",
+      expectedItems: new Map([[$item`plain brown wrapper`, 1]]),
+      expectedOutsideItems: new Map([[$item`plain brown wrapper`, 1]]),
+      expectedInsideItems: new Map(),
+      expectedMeat: 1,
+    },
+  ] as const)(
+    "should correctly parse outside and inside of gift message",
+    ({
+      input,
+      expectedMessage,
+      expectedOutsideNote,
+      expectedInsideNote,
+      expectedItems,
+      expectedOutsideItems,
+      expectedInsideItems,
+      expectedMeat,
+    }) => {
+      mocked(visitUrl).mockReturnValueOnce(JSON.stringify([input]));
+
+      const kmails = Kmail.inbox();
+      expect(kmails).toHaveLength(1);
+      expect(kmails[0].message).toEqual(expectedMessage);
+      expect(kmails[0].outsideNote).toEqual(expectedOutsideNote);
+      expect(kmails[0].insideNote).toEqual(expectedInsideNote);
+      expect(kmails[0].items()).toEqual(expectedItems);
+      expect(kmails[0].outsideItems()).toEqual(expectedOutsideItems);
+      expect(kmails[0].insideItems()).toEqual(expectedInsideItems);
+      expect(kmails[0].meat()).toEqual(expectedMeat);
+    }
+  );
 });

--- a/__tests__/__mocks__/kolmafia.ts
+++ b/__tests__/__mocks__/kolmafia.ts
@@ -1,15 +1,20 @@
+import { jest } from "@jest/globals";
+
+import type RuntimeLibrary from "kolmafia";
+import Mocked = jest.Mocked;
+
+type Kolmafia = typeof RuntimeLibrary;
+
+type N = number | string | (number | string)[];
+
 function mockOneOrMany<
   Ctor extends new (name: string) => T,
   T extends MafiaClass
->(
-  ctor: Ctor,
-  n: number | string | (number | string)[],
-  knownInstances: T[]
-): T | T[] {
+>(ctor: Ctor, n: N, knownInstances: T[]): T | T[] {
   function mockOne(name: number | string): T {
     // to make mocking easier, we'll just tread ids as names
     if (typeof name === "number") {
-      name = name.toString();
+      name = `[${name.toString()}]`;
     }
     const existingInstance = knownInstances.find((i) => i.name === name);
     if (existingInstance) {
@@ -30,53 +35,79 @@ abstract class MafiaClass {
   constructor(readonly name: string) {}
 }
 
-export class Bounty extends MafiaClass {
+class Bounty extends MafiaClass {
   private static knownInstances: Bounty[] = [];
-  static get = jest.fn((n) => mockOneOrMany(Bounty, n, Bounty.knownInstances));
+
+  static get = jest.fn((n: N) =>
+    mockOneOrMany(Bounty, n, Bounty.knownInstances)
+  );
+
   static all = jest.fn(() => Bounty.knownInstances);
+
   static none = {};
 }
-export class Class extends MafiaClass {
+class Class extends MafiaClass {
   private static knownInstances: Class[] = [];
-  static get = jest.fn((n) => mockOneOrMany(Class, n, Class.knownInstances));
+
+  static get = jest.fn((n: N) => mockOneOrMany(Class, n, Class.knownInstances));
+
   static all = jest.fn(() => Class.knownInstances);
+
   static none = {};
 }
-export class Coinmaster extends MafiaClass {
+class Coinmaster extends MafiaClass {
   private static knownInstances: Coinmaster[] = [];
-  static get = jest.fn((n) =>
+
+  static get = jest.fn((n: N) =>
     mockOneOrMany(Coinmaster, n, Coinmaster.knownInstances)
   );
+
   static all = jest.fn(() => Coinmaster.knownInstances);
+
   static none = {};
 }
-export class Effect extends MafiaClass {
+class Effect extends MafiaClass {
   private static knownInstances: Effect[] = [];
-  static get = jest.fn((n) => mockOneOrMany(Effect, n, Effect.knownInstances));
+
+  static get = jest.fn((n: N) =>
+    mockOneOrMany(Effect, n, Effect.knownInstances)
+  );
+
   static all = jest.fn(() => Effect.knownInstances);
+
   static none = {};
 }
-export class Element extends MafiaClass {
+class Element extends MafiaClass {
   private static knownInstances: Element[] = [];
-  static get = jest.fn((n) =>
+
+  static get = jest.fn((n: N) =>
     mockOneOrMany(Element, n, Element.knownInstances)
   );
+
   static all = jest.fn(() => Element.knownInstances);
+
   static none = {};
 }
-export class Familiar extends MafiaClass {
+class Familiar extends MafiaClass {
   private static knownInstances: Familiar[] = [];
-  static get = jest.fn((n) =>
+
+  static get = jest.fn((n: N) =>
     mockOneOrMany(Familiar, n, Familiar.knownInstances)
   );
+
   static all = jest.fn(() => Familiar.knownInstances);
+
   static none = {};
 }
-export class Item extends MafiaClass {
+class Item extends MafiaClass {
   private static knownInstances: Item[] = [];
+
   private static mockId = 11;
-  static get = jest.fn((n) => mockOneOrMany(Item, n, Item.knownInstances));
+
+  static get = jest.fn((n: N) => mockOneOrMany(Item, n, Item.knownInstances));
+
   static all = jest.fn(() => Item.knownInstances);
+
   static none = new Item("", -1, "");
 
   constructor(
@@ -88,89 +119,184 @@ export class Item extends MafiaClass {
   }
 }
 
-export class Location extends MafiaClass {
+class Location extends MafiaClass {
   private static knownInstances: Location[] = [];
-  static get = jest.fn((n) =>
+
+  static get = jest.fn((n: N) =>
     mockOneOrMany(Location, n, Location.knownInstances)
   );
+
   static all = jest.fn(() => Location.knownInstances);
+
   static none = {};
 }
-export class Modifier extends MafiaClass {
+class Modifier extends MafiaClass {
   private static knownInstances: Modifier[] = [];
-  static get = jest.fn((n) =>
+
+  static get = jest.fn((n: N) =>
     mockOneOrMany(Modifier, n, Modifier.knownInstances)
   );
+
   static all = jest.fn(() => Modifier.knownInstances);
+
   static none = {};
 }
-export class Monster extends MafiaClass {
+class Monster extends MafiaClass {
   private static knownInstances: Monster[] = [];
-  static get = jest.fn((n) =>
+
+  static get = jest.fn((n: N) =>
     mockOneOrMany(Monster, n, Monster.knownInstances)
   );
+
   static all = jest.fn(() => Monster.knownInstances);
+
   static none = {};
 }
-export class Path extends MafiaClass {
+class Path extends MafiaClass {
   private static knownInstances: Path[] = [];
-  static get = jest.fn((n) => mockOneOrMany(Path, n, Path.knownInstances));
+
+  static get = jest.fn((n: N) => mockOneOrMany(Path, n, Path.knownInstances));
+
   static all = jest.fn(() => Path.knownInstances);
+
   static none = {};
 }
-export class Phylum extends MafiaClass {
+class Phylum extends MafiaClass {
   private static knownInstances: Phylum[] = [];
-  static get = jest.fn((n) => mockOneOrMany(Phylum, n, Phylum.knownInstances));
+
+  static get = jest.fn((n: N) =>
+    mockOneOrMany(Phylum, n, Phylum.knownInstances)
+  );
+
   static all = jest.fn(() => Phylum.knownInstances);
+
   static none = {};
 }
-export class Servant extends MafiaClass {
+class Servant extends MafiaClass {
   private static knownInstances: Servant[] = [];
-  static get = jest.fn((n) =>
+
+  static get = jest.fn((n: N) =>
     mockOneOrMany(Servant, n, Servant.knownInstances)
   );
+
   static all = jest.fn(() => Servant.knownInstances);
+
   static none = {};
 }
-export class Skill extends MafiaClass {
+class Skill extends MafiaClass {
   private static knownInstances: Skill[] = [];
-  static get = jest.fn((n) => mockOneOrMany(Skill, n, Skill.knownInstances));
+
+  static get = jest.fn((n: N) => mockOneOrMany(Skill, n, Skill.knownInstances));
+
   static all = jest.fn(() => Skill.knownInstances);
+
   static none = {};
 }
-export class Slot extends MafiaClass {
+class Slot extends MafiaClass {
   private static knownInstances: Slot[] = [];
-  static get = jest.fn((n) => mockOneOrMany(Slot, n, Slot.knownInstances));
+
+  static get = jest.fn((n: N) => mockOneOrMany(Slot, n, Slot.knownInstances));
+
   static all = jest.fn(() => Slot.knownInstances);
+
   static none = {};
 }
-export class Stat extends MafiaClass {
+class Stat extends MafiaClass {
   private static knownInstances: Stat[] = [];
-  static get = jest.fn((n) => mockOneOrMany(Stat, n, Stat.knownInstances));
+
+  static get = jest.fn((n: N) => mockOneOrMany(Stat, n, Stat.knownInstances));
+
   static all = jest.fn(() => Stat.knownInstances);
+
   static none = {};
 }
-export class Thrall extends MafiaClass {
+class Thrall extends MafiaClass {
   private static knownInstances: Thrall[] = [];
-  static get = jest.fn((n) => mockOneOrMany(Thrall, n, Thrall.knownInstances));
+
+  static get = jest.fn((n: N) =>
+    mockOneOrMany(Thrall, n, Thrall.knownInstances)
+  );
+
   static all = jest.fn(() => Thrall.knownInstances);
+
   static none = {};
 }
-export class Vykea extends MafiaClass {
+class Vykea extends MafiaClass {
   private static knownInstances: Vykea[] = [];
-  static get = jest.fn((n) => mockOneOrMany(Vykea, n, Vykea.knownInstances));
+
+  static get = jest.fn((n: N) => mockOneOrMany(Vykea, n, Vykea.knownInstances));
+
   static all = jest.fn(() => Vykea.knownInstances);
+
   static none = {};
 }
 
-export const getPlayerName = jest.fn();
-export const getPlayerId = jest.fn();
+const kolmafiaClasses = {
+  Bounty,
+  Class,
+  Coinmaster,
+  Effect,
+  Element,
+  Familiar,
+  Item,
+  Location,
+  Modifier,
+  Monster,
+  Path,
+  Phylum,
+  Servant,
+  Skill,
+  Slot,
+  Stat,
+  Thrall,
+  Vykea,
+};
+const kolmafiaMocks: Record<string, unknown> = {
+  ...kolmafiaClasses,
+};
 
-export const getProperty = jest.fn();
+const actualKolmafia = jest.requireActual("kolmafia") as Kolmafia;
 
-export const isGiftable = jest.fn();
+// we have to mock the functions ourselves, because with automock all functions
+// share the same `warn` mock
+for (const [key, value] of Object.entries(actualKolmafia)) {
+  if (typeof value !== "function") {
+    continue;
+  }
+  const descriptor = Object.getOwnPropertyDescriptor(value, "prototype");
+  if (descriptor && !descriptor.writable) {
+    if (!(key in kolmafiaClasses)) {
+      console.warn("Missing MafiaClass from kolmafia mock:", key);
+    }
+    continue;
+  }
 
-export const print = jest.fn((msg) => console.log(`[kolmafia.print] ${msg}`));
+  kolmafiaMocks[key] = jest.fn();
+}
 
-export const toItem = jest.fn((name) => Item.get(name));
-export const visitUrl = jest.fn();
+const kolmafia = kolmafiaMocks as Mocked<Kolmafia>;
+
+kolmafia.logprint.mockImplementation((msg) =>
+  console.log(`[kolmafia.logprint] ${msg}`)
+);
+kolmafia.print.mockImplementation((msg?) =>
+  console.log(`[kolmafia.print] ${msg}`)
+);
+kolmafia.printHtml.mockImplementation((msg) =>
+  console.log(`[kolmafia.printHtml] ${msg}`)
+);
+
+kolmafia.getMonsters.mockImplementation(() => []);
+kolmafia.nowToString.mockImplementation(() => new Date().toISOString());
+kolmafia.toInt.mockImplementation((value) => parseInt(value as any, 10));
+kolmafia.toPlural.mockImplementation((item) => item.plural);
+kolmafia.toString.mockImplementation((value) => value.toString());
+
+const mockProperties = new Map<string, string>();
+export const clearMockProperties = () => mockProperties.clear();
+kolmafia.getProperty.mockImplementation((key) => mockProperties.get(key) ?? "");
+kolmafia.setProperty.mockImplementation((key, value) =>
+  mockProperties.set(key, value)
+);
+
+module.exports = kolmafia;

--- a/src/Kmail.ts
+++ b/src/Kmail.ts
@@ -206,13 +206,8 @@ export default class Kmail {
   }
 
   private constructor(rawKmail: RawKmail) {
-    const date = new Date(rawKmail.localtime);
-    // Date come from KoL formatted with YY and so will be parsed 19YY, which is wrong.
-    // We can safely add 100 because if 19YY was a leap year, 20YY will be too!
-    date.setFullYear(date.getFullYear() + 100);
-
     this.id = Number(rawKmail.id);
-    this.date = date;
+    this.date = new Date(Number(rawKmail.azunixtime) * 1000);
     this.type = rawKmail.type as Kmail["type"];
     this.senderId = Number(rawKmail.fromid);
     this.senderName = rawKmail.fromname;

--- a/src/Kmail.ts
+++ b/src/Kmail.ts
@@ -1,3 +1,4 @@
+import { decode as decodeEntities } from "html-entities";
 import { extractMeat, isGiftable, Item, visitUrl } from "kolmafia";
 import { extractItems } from "./lib";
 import { combineQuery, EMPTY_VALUE, fetchUrl, Query } from "./url";
@@ -249,9 +250,9 @@ export default class Kmail {
       insideText !== undefined ? split(insideText) : [];
 
     return {
-      outsideNote,
+      outsideNote: decodeEntities(outsideNote),
       outsideAttachments,
-      insideNote,
+      insideNote: insideNote && decodeEntities(insideNote),
       insideAttachments,
     };
   }

--- a/src/Kmail.ts
+++ b/src/Kmail.ts
@@ -1,10 +1,5 @@
-import {
-  extractItems,
-  extractMeat,
-  isGiftable,
-  Item,
-  visitUrl,
-} from "kolmafia";
+import { extractMeat, isGiftable, Item, visitUrl } from "kolmafia";
+import { extractItems } from "./lib";
 import { combineQuery, EMPTY_VALUE, fetchUrl, Query } from "./url";
 import { arrayToCountedMap, chunk } from "./utils";
 
@@ -25,6 +20,15 @@ export default class Kmail {
   readonly senderId: number;
   readonly senderName: string;
   readonly rawMessage: string;
+
+  private _parsedMessageParts:
+    | {
+        outsideNote: string;
+        outsideAttachments: string | null;
+        insideNote: string | null;
+        insideAttachments: string | null;
+      }
+    | undefined;
 
   /**
    * Parses a kmail from KoL's native format
@@ -224,14 +228,69 @@ export default class Kmail {
     return Kmail.delete([this]) === 1;
   }
 
+  private get _messageParts() {
+    return (this._parsedMessageParts ??= this._parseMessageParts());
+  }
+
+  private _parseMessageParts() {
+    let text = this.rawMessage;
+    let insideText: string | undefined;
+    if (this.type === "normal") {
+      // strip potential valentine
+      if (text.startsWith("<center>")) {
+        const endIdx = text.indexOf("</center>");
+        text = text.slice(endIdx + 9);
+      }
+    } else if (this.type === "giftshop") {
+      [text, insideText] = text.split("<p>Inside Note:<p>");
+    }
+    const split = (s: string) => {
+      const idx = s.indexOf("<");
+      if (idx === -1) return [s];
+      return [s.slice(0, idx), s.slice(idx)];
+    };
+    const [outsideNote, outsideAttachments = null] = split(text);
+    const [insideNote = null, insideAttachments = null] =
+      insideText !== undefined ? split(insideText) : [];
+
+    return {
+      outsideNote,
+      outsideAttachments,
+      insideNote,
+      insideAttachments,
+    };
+  }
+
   /**
    * Get message contents without any HTML from items or meat
    *
    * @returns Cleaned message contents
    */
   get message(): string {
-    const match = this.rawMessage.match(/^(.*?)</s);
-    return match ? match[1] : this.rawMessage;
+    const { outsideNote, insideNote } = this._messageParts;
+    if (insideNote !== null) {
+      return `${outsideNote}\n\nInside Note:\n${insideNote}`;
+    }
+    return outsideNote;
+  }
+
+  /**
+   * Get the note on the outside of the gift. If the kmail is not a gift,
+   * this will be the entire message.
+   *
+   * @returns Note on the outside of the gift, or the entire message for non-gifts
+   */
+  get outsideNote(): string {
+    return this._messageParts.outsideNote;
+  }
+
+  /**
+   * Get the note on the inside of the gift
+   *
+   * @returns Note on the inside of the gift
+   */
+  get insideNote(): string | null {
+    return this._messageParts.insideNote;
   }
 
   /**
@@ -240,11 +299,31 @@ export default class Kmail {
    * @returns Map of items attached to the kmail and their quantities
    */
   items(): Map<Item, number> {
-    return new Map(
-      Object.entries(extractItems(this.rawMessage)).map(
-        ([itemName, quantity]) => [Item.get(itemName), quantity] as const
-      )
-    );
+    const { outsideAttachments, insideAttachments } = this._messageParts;
+    return extractItems(`${outsideAttachments}${insideAttachments}`);
+  }
+
+  /**
+   * Get items attached to the outside of the gift, which should be
+   * just the gift wrapper for giftshop items, and all items for normal kmails
+   *
+   * @returns Map of items attached to the kmail and their quantities
+   */
+  outsideItems(): Map<Item, number> {
+    const { outsideAttachments } = this._messageParts;
+    if (!outsideAttachments) return new Map();
+    return extractItems(outsideAttachments);
+  }
+
+  /**
+   * Get items attached to the inside of the gift
+   *
+   * @returns Map of items attached to the kmail and their quantities
+   */
+  insideItems(): Map<Item, number> {
+    const { insideAttachments } = this._messageParts;
+    if (!insideAttachments) return new Map();
+    return extractItems(insideAttachments);
   }
 
   /**
@@ -253,7 +332,9 @@ export default class Kmail {
    * @returns Meat attached to the kmail
    */
   meat(): number {
-    return extractMeat(this.rawMessage);
+    const { outsideAttachments, insideAttachments } = this._messageParts;
+    if (!outsideAttachments && !insideAttachments) return 0;
+    return extractMeat(`${outsideAttachments}${insideAttachments}`);
   }
 
   /**

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -12,6 +12,7 @@ import {
   elementalResistance,
   equip,
   equippedItem,
+  extractItems as kolmafiaExtractItems,
   Familiar,
   fullnessLimit,
   getCampground,
@@ -1256,4 +1257,21 @@ export function withCombatFlags<T>(
  */
 export function haveIntrinsic(effect: Effect): boolean {
   return haveEffect(effect) >= 2147483647;
+}
+
+/**
+ * Extracts a map of gained items from a string, for example from the result
+ * of a combat.
+ *
+ * NOTE: Make sure you trust the source of that text.
+ *
+ * @param text The text to extract items from
+ * @returns A map of items and their quantities
+ */
+export function extractItems(text: string): Map<Item, number> {
+  return new Map(
+    Object.entries(kolmafiaExtractItems(text)).map(
+      ([itemName, quantity]) => [Item.get(itemName), quantity] as const
+    )
+  );
 }


### PR DESCRIPTION
* correctly parse inside and outside note of gift message
* extract items and meat only from the actual attachments (not the text)
* don't swallow actually messages of valentine cards
* decode html entities in message
* use unixtime as source for the message date
