### PR TITLE
Fix errors when creating new macros"

### DIFF
--- a/src/combat.ts
+++ b/src/combat.ts
@@ -34,7 +34,8 @@ const MACRO_NAME = "Script Autoattack Macro";
  */
 export function getMacroId(name = MACRO_NAME): number {
   const query = `//select[@name="macroid"]/option[text()="${name}"]/@value`;
-  let macroMatches = xpath(visitUrl("account_combatmacros.php"), query);
+  const macroText = visitUrl("account_combatmacros.php");
+  let macroMatches = xpath(macroText, query);
 
   if (macroMatches.length === 0) {
     visitUrl("account_combatmacros.php?action=new");
@@ -45,6 +46,13 @@ export function getMacroId(name = MACRO_NAME): number {
   }
 
   if (macroMatches.length === 0) {
+    // We may have hit the macro cap
+    if (xpath(macroText, '//select[@name="macroid"]/option').length >= 128) {
+      throw new InvalidMacroError(
+        `Please delete at least one existing macro to make some space for Libram`,
+      );
+    }
+    // Otherwise who knows why it failed
     throw new InvalidMacroError(`Could not find or create macro ${name}`);
   }
 

--- a/src/combat.ts
+++ b/src/combat.ts
@@ -33,22 +33,22 @@ const MACRO_NAME = "Script Autoattack Macro";
  * @returns {number} The macro ID.
  */
 export function getMacroId(name = MACRO_NAME): number {
-  const macroMatches = xpath(
-    visitUrl("account_combatmacros.php"),
-    `//select[@name="macroid"]/option[text()="${name}"]/@value`,
-  );
+  const query = `//select[@name="macroid"]/option[text()="${name}"]/@value`;
+  let macroMatches = xpath(visitUrl("account_combatmacros.php"), query);
+
   if (macroMatches.length === 0) {
     visitUrl("account_combatmacros.php?action=new");
     const newMacroText = visitUrl(
       `account_combatmacros.php?macroid=0&name=${name}&macrotext=abort&action=save`,
     );
-    return parseInt(
-      xpath(newMacroText, `//input[@name=${name}]/@value`)[0],
-      10,
-    );
-  } else {
-    return parseInt(macroMatches[0], 10);
+    macroMatches = xpath(newMacroText, query);
   }
+
+  if (macroMatches.length === 0) {
+    throw new InvalidMacroError(`Could not find or create macro ${name}`);
+  }
+
+  return parseInt(macroMatches[0], 10);
 }
 
 type ItemOrName = Item | string;


### PR DESCRIPTION
- **make Macro.rename return a macro; create static analogue**
- **Initial Spacegate commit**
- **additional logic for dailing**
- **Initial Spacegate commit**
- **additional logic for dailing**
- ** simplify getHazardEquip, equip is always array**
- **use phredds hazardequip map suggestion**
- **Change Vaccine number logic**
- **initial commit**
- **Export correctly**
- **First draft at modeable caching**
- **Change paradigm; this code never touches the user, so it can be slicker**
- **Add some docstrings**
- **Update property types automatically**
- **Add basic support for barrel shrine (smash party)**
- **Upgrade mafia to 5.x**
- **Always compare fuel price to the second best option**
- **If the difference between min & max adventures is less than 1, we get a full adventure from special seasoning**
- **expectedAdventures change, and compare adventures with and without seasoning instead of min and max adventures**
- **Use values already in array**
- **use max instead, recordedMax can be null perhaps**
- **Remove emdash and endash re: Katarn**
- **Actually export Cartography**
- **trackVoteMonster is a fake boolean property**
- **Fix value computation for trial items.**
- **Remove unused import.**
- **We have to visit the friar**
- **Update peer dependency as well**
- **Update property types automatically**
- **Bump props**
- **First pass fallbot support**
- **track current location**
- **Add upgrading support**
- **Upgrade eslint-plugin-libram**
- **blackhat => cowcatcher**
- **Add 1 to Math.max so it actually does something**
- **Allow functional inputs to sendTo**
- **Allow array inputs as well**
- **sendTo now returns Location | null**
- **Return an Item[], prefer Item.all() to $items``**
- **Don't insert all of our food**
- **Docstrings**
- **capitalization**
- **False positive is less harmful than false negative**
- **Update package.json**
- **Support printing modtraces to log**
- **Allow passing a forced mode setting for modeables**
- **Switch to buy instead of retrieveItem**
- **Can't run choice 3 for fallbot**
- **Get that last runChoice(3)**
- **Export various mode functions**
- **Maybe prevent NPE for clearAutoAttackMacros**
- **Delete IDs as well**
- **Update package.json**
- **Let us overfuel our asdon**
- **Remove print**
- **Create ifNot macro method**
- **Docstring**
- **Update package.json**
- **Bam BOO! ==> BamBOO!**
- **Try to fix github action.**
- **Further work on github action.**
- **Basic README.**
- **Use git-publish-subdir-action to simplify workflow**
- **line ending**
- **still gotta yarn install**
- **More workflow funging**
- **Trying to fix CI again.**
- **Add debug log level**
- **Add debug logging to CrystalBall.ponder and canVisitUrl**
- **use retrieveItem in ronin**
- **Check if the The Jokester's gun can be equipped**
- **Create enum, and allow users to set log level**
- **Fix build error**
- **Adjust ascension detection to work in compact character pane**
- **Fix detection for full character pane**
- **Update Valhalla detection**
- **Remove specific message for failure to detect ascension**
- **Add reagnimated gnome**
- **Update property types automatically**
- **Update package.json**
- **Make parts non-meltable and cap advs at 1**
- **Return true if already have part**
- **Fix ascension detection (again)**
- **Update property types automatically**
- **Update src/resources/2012/ReagnimatedGnome.ts**
- **Add a function to clear the outfit cache**
- **Only mode items when a configuration is given**
- **Equip robortender to feed it**
- **Update property types automatically**
- **Update package.json**
- **Add new functionality to BeachComb**
- **Remove workshed from ascend.ts**
- **Upgrade eslint-plugin-libram**
- **First layer of trainrealm support**
- **Use katarn's tuple code**
- **Overload sum**
- **Add garbo's maxBy**
- **Remove redundant function**
- **Make maxBy consistent**
- **Update station names**
- **Don't log when equipping same outfit.**
- **expose fallbot uniques**
- **Update underwater handling**
- **legs**
- **Update property types automatically**
- **Add next() function**
- **v0.7.7**
- **Fix canConfigure**
- **Fix configuration logic**
- **v0.7.8**
- **There are too many trainset prefs**
- **Run the choice properly**
- **v0.7.9**
- **Have logger print to session log, since printHtml doesn't.**
- **Don't warn on failed outfit cache short circuit.**
- **Swap out webpack for esbuild.**
- **Update property types automatically**
- **Add headAvailable function**
- **Actually use these utility functions**
- **Postmerge linting**
- **Cut out final bit of lodash**
- **Print caught errors in CommunityService**
- **Reuse fallbot if we've left the page during sendTo**
- **Actually resolve merge conflicts**
- **Update property types automatically**
- **Update package.json**
- **Add Fidoxene support for CS**
- **Update substring combat skills & items**
- **Commentary**
- **Add DeckOfEveryCard**
- **Update property types automatically**
- **Update property types automatically**
- **export mergeMaximizeOptions function**
- **v0.7.18**
- **v0.7.11**
- **Create examine function**
- **Spice Ghost doesn't count for CS**
- **Update property types automatically**
- **Make Session.diff handle negatives better**
- **Handle it in one iteration**
- **Update property types automatically**
- **Create some additional utility functions**
- **Documentation**
- **finalize docstrings**
- **rufusTarget and have**
- **First pass of ShadowRealm functions**
- **add chooseQuest**
- **Export ClosedCircuitPayphone**
- **Update property types automatically**
- **Add rifts function**
- **Add the jsdoc plugin**
- **Apply automatic fixes to jsdoc issues**
- **Mark jsdoc issues as an error**
- **Configure eslint jsdoc plugin for a typedoc project**
- **Fix errors in combat.ts**
- **Allow some tags that are defined in TypeDoc but are not valid JSDoc tags**
- **Fix jsdocs in ascend.ts, and fix some formatting**
- **Only require jsdocs for unexported functions**
- **Fix clan jsdocs**
- **Fix up definition of Copier class**
- **Remove core-js and just import a Array.prototype.flat shim**
- **Fix issues in Kmail**
- **Fix jsdoc issues for lib**
- **Add missing one for lib.ts**
- **Fix jsdocs for maximize.ts**
- **modifier and mood jsdocs**
- **Fix property jsdocs**
- **Major refactor using RegExp**
- **Minor refactoring**
- **More informative variable names**
- **Use consts**
- **Fix jsdoc issues in propertyTypes**
- **Fix jsdocs in session**
- **Fix jsdoc issues in utils.ts**
- **Update docs for LibramSummon, putty-likes, TrainSet, and ClosedCircuitPayphone**
- **Docs update for JuneCleaver**
- **A few other fixes**
- **Grey Goose docs**
- **Fallbot docs upgrade; CLL docs upgrade**
- **Orb docs upgrade**
- **Document Guzzlr**
- **Update property types automatically**
- **Cartography docs**
- **Beach Comb docs**
- **Use literals and sum(); also allow custom colors**
- **ActionSource and Stickers now have full docs**
- **Add more jsdocs**
- **Rather tha commenting out Party Mouse crown code, just make it a conditional that we don't (currently) use**
- **Add docs to diet.ts**
- **Fix last diet bits**
- **Add jshints to 2011 items**
- **Add jsdocs for RainDoh**
- **Finish 2012 jsdocs**
- **Restructure Dungeon to make docs update easier**
- **2018 resources**
- **LOV tunnel, Deck of Every Card (includes bugfixes for Deck)**
- **Pantogram documentation**
- **Asdon docs; export isFuelItem**
- **Prefer `sum` to `sumNumbers` with `map`**
- **Create byIngress function**
- **Circular imports**
- **Mumming trunk docs & bugfix**
- **2016 iotms**
- **Chateau, Barrels, Mayo**
- **2013-2014**
- **Disable jsdoc errors for Dinsey and Spacegate temporarily**
- **Only warn about jsdocs in remaining files**
- **Add jsdocs to the tools**
- **Fix jsdoc linting**
- **Update property types automatically**
- **v0.7.12**
- **Fix JSDoc**
- **More JSDoc fixes**
- **Use node 16 for publish**
- **Update package.json**
- **Update property types automatically**
- **Use `sum` for smashParty**
- **Impement flat in utils**
- **Remove shim**
- **Remove all webpack stuff that is still hanging around**
- **Update property types automatically**
- **Start expanding latte code**
- **Prune imports**
- **consistency**
- **restructure to be objects instead of arrays**
- **Update ingredients to match mafia**
- **Add currentIngredients**
- **Fix imports**
- **use generic typing for locationOf**
- **v0.7.14**
- **Fix chooseQuest**
- **No magic numbers**
- **Update package.json**
- **Fix calculation of grey goose familiar experience**
- **Add fakeUse function; add submitQuest to CCPayphone**
- **fakeUse ==> directlyUse**
- **Update fallbot to directly use directlyUse**
- **add documentation for spacegate and dinsey**
- **Update property types automatically**
- **Add packet of rock seeds as a garden**
- **bump packages**
- **Monkey functions**
- **stop using directlyUse for barrelshrine**
- **allow bad return values for CommunityService.run**
- **use `prepareForAdventure`**
- **comment & streamline unwishableEffects**
- **use only one map**
- **Automatically check for overlapping item and skill names on build**
- **delete now-redundant file**
- **use checkpoint when preparing for adventure**
- **v0.7.16**
- **import flat**
- **default `flat` to infinite depth**
- **Update docstring**
- **v0.7.17**
- **create getTotalModifier function**
- **don't spread the input of wishableItems; fix the typing on flat**
- **Prune trivial exports**
- **fix ActionSource.ts**
- **Add optional filters to CursedMonkeyPaw.wishableItems**
- **Remove more trivial exports**
- **Rehaul crown of thrones**
- **`as const` the ridingFamiliars**
- **make `createRiderMode` accept a partial object; create `createModifierValueFunction`**
- **create `hasRiderMode`**
- **spread => rested**
- **create overloaded `unequip` function**
- **additional comments**
- **merge filters**
- **and debug logging**
- **add debug logging**
- **rufusDesiredEntity should be a monster**
- **update props**
- **unbreak ClosedCircuitPayphone.ts**
- **lint**
- **allow users to externally start timer for tasks and tests**
- **let nullish coalescence take care of it**
- **docstrings**
- **make tasks and tests work more similarly**
- **prematurely return when appropriate**
- **code cleanup**
- **add messages to aborts**
- **wrap in quotes**
- **make it a separate method**
- **Update package.json**
- **Update package.json**
- **stocking mimic in the bjorn drops meat**
- **Update property types automatically**
- **print "update kolmafia" message when a Type.get fails**
- **update messaging**
- **optimize regex**
- **grammar in the warning, print in red**
- **also apply it to the single constant**
- **reduce code duplication**
- **let people do $items.all()**
- **commas are robots too**
- **phred knows best**
- **now that's a function**
- **export modifier types**
- **preliminary cincho support**
- **off-by-one error in cinchRestoredBy**
- **add getCampground to session's inventory**
- **check closet, display, and storage for session items**
- **add meat as well**
- **Add and use BeachComb.available() that works with the daypass.**
- **Revert "commas are robots too"**
- **export cincho**
- **use Type.name, instead of Type**
- **we never actually use that capture group**
- **Update property types automatically**
- **v0.8.1**
- **ChibiBuddy is like a foldable**
- **Format**
- **upgrade packages**
- **prefer `id` to `toInt`**
- **replace certain item names in maximizer code with itemids accompanied by pilcrews**
- **only replace html entities with pilcrows; use quotes for everything else**
- **`.includes` beats `.match` when we're testing something this simple**
- **return 0 if cincho isn't owned**
- **Update property types automatically**
- **export `Card` and `cards` from DeckOfEveryCard**
- **Update property types automatically**
- **Update sign functions to be useful outside of ascension**
- **Add utility function to select a random element from an array**
- **Add CampAway resource**
- **Remove extra space**
- **Fix accidentally inverted canGaze**
- **Simplify signIdToName and reverse**
- **Add return types explicitly**
- **Title case the moon sign**
- **Format**
- **use a getter instead of relying on as const**
- **use Object.freeze instead**
- **v0.8.2**
- **0 is actually a bad moon (but isn't bad moon)**
- **Can't use regexp in overlapping names**
- **v0.8.3**
- **Update property types automatically**
- **Add numeric property increment and decremet. Make set return value that was just set**
- **Do some hygiene on property setting within libram**
- **Horse support**
- **crazyHorseStats should work even if you're unhorseried**
- **Add additional checks to changeHorse**
- **Consider every familiar in the bjorn, even ones that don't have interesting drops**
- **Invert condition**
- **initial $modifier support**
- **Update property types automatically**
- **Support clan names with entities.**
- **expand Delayed<T> to Delayed<T, S>**
- **lint.**
- **v0.8.4**
- **Fix timers in CS**
- **Update property types automatically**
- **Kmails can have type `"normal"`**
- **Update property types automatically**
- **v0.8.5**
- **Update property types automatically**
- **Basic August support**
- **fix Horsery.current()**
- **v0.8.6**
- **-1. not +1**
- **Fix names**
- **Add getAugustCast and getTodayCast**
- **fix import issues**
- **import order is apparently a thing?**
- **prettier**
- **Initial Jung Man implementation**
- **Export jung man**
- **Create and use `Range` utility type**
- **don't use array lookup for todaysSkill()**
- **allow tracking only mafia session data**
- **Update property types automatically**
- **v0.8.7**
- **add convenience function AugustScepter.canCast()**
- **export AugustScepter.today()**
- **add have() guard**
- **skilsl**
- **Basic Support for Heavy Rains path**
- **add offhand remarkable to cache key**
- **Update property types automatically**
- **Remove magic numbers; Constantize return values**
- **v0.8.8**
- **Update property types automatically**
- **v0.8.9**
- **Update property types automatically**
- **Create `gameDay`; use it for August support**
- **use regexps instead of modulo**
- **don't import from `../..`**
- **lint**
- **Update property types automatically**
- **v0.8.10**
- **Accidentally added a dependency, removed**
- **v0.8.11**
- **Do not try to shove more food into an overflowing stomach**
- **yarn run format**
- **Reorganise and clairfy comment**
- **v0.8.12**
- **Add default upper limits for legendary foods (#524)**
- **Update property types automatically**
- **Add turns as a component of session**
- **Actually export the value of the turns**
- **Add MPA calculation functions**
- **clarify outlier function name**
- **Hoist garbo utility functions up into libram (#528)**
- **Clean up interface, export tyeps**
- **v0.8.13**
- **Update ascend to take object parameters instead of long list of args**
- **Add kolGender parameter and support for defaultGenderOverride to ascend**
- **Switch to KolGender enum and simplified defaulting format**
- **feedback**
- **Actually export LookingGlass**
- **Update property types automatically**
- **Fix fractional potion mood**
- **lint**
- **v0.8.14**
- **upgrade kolmafia**
- **ponder only when there's a chance we've invalidated our ponder**
- **account for toastergazing in ponder caching (#535)**
- **basic gingerbread support**
- **`canJudgeFudge`**
- **create `hypotheticalModifier` wrapper, apply it to predictions**
- **create `turnsSavedBy` method**
- **docstring**
- **clamp values**
- **remove circular import**
- **account for disgeist, mu, and parrot**
- **weird that eslint doesn't care about this**
- **rename `getNoon`**
- **rename `getMidnight`**
- **v0.8.15**
- **whet stone**
- **Consistent with mayoflex**
- **add GuidetoBurningLeaves**
- **Complete recommended updates**
- **Yarn Format per request.**
- **Let's map monsters too!**
- **Add a canBurnFor**
- **Add comments**
- **Fixed typo**
- **Add fire jump, I guess. Why not.**
- **Updated name to BurningLeaves**
- **Correct import/ezport**
- **Switch back to Union**
- **Update src/resources/2023/BurningLeaves.ts**
- **Update src/resources/2023/BurningLeaves.ts**
- **Update comments**
- **Update src/resources/2023/BurningLeaves.ts**
- **Update BurningLeaves.ts**
- **Item | Monster didn't work, cleaned up a bit**
- **fix "undefined" issue. Code should work now.**
- **Update BurningLeaves.ts**
- **Removed most features; [leaves] in Mafia**
- **Update property types automatically**
- **Final edit**
- **Add visitURL based on testing.**
- **switch to `runChoice`**
- **actually upgrade eslint-plugin-libram**
- **fix Map typing**
- **update peer dependency**
- **update YML files?**
- **remove main.php hits**
- **v0.8.16**
- **Update property types automatically**
- **Fix amount checks in BurningLeaves**
- **Resolve circular import in CrystalBall**
- **Resolve circular import in CampAway, extract MoonSign**
- **Make `lastAdventure` and `nextAdventure` Locations**
- **Update property types automatically**
- **use `get("lastAdventure")` instead of `myLocation` for FloristFriar**
- **remove unnecessary typing**
- **Fix check for Jumping in the Flames**
- **Let BurningLeaves.jumpInFire() return a success value**
- **Add test for KMail**
- **Add fetchUrl, fix KMail message encoding**
- **Add modeable support for jill**
- **update typing of the PropertiesManager to avoid having to cast properties**
- **delete properties that didn't exist prior to the PM call**
- **v0.8.17**
- **Fix disgeist handling for CS predictor**
- **Add familiar to burnFor**
- **Update property types automatically**
- **delete Path.ts**
- **remove `path` fron index.ts**
- **add description**
- **v0.8.18**
- **sidestep problems with `{ pet: undefined }`**
- **create `get` and `set` functions for account combat flags**
- **might as well make a `with` function too**
- **Update property types automatically**
- **split banish and free runs**
- **quest items**
- **don't expose quest items yet**
- **fix comment for green smoke bomb**
- **fix green smoke bomb, quest items**
- **uncomment GSB, add ELG to everything**
- **Update property types automatically**
- **commenting it up**
- **use more consisstent filters and type guards**
- **v0.8.19**
- **fix import**
- **only get 1 of the free run items**
- **check if we have quest items**
- **Update FreeRun.ts**
- **Update property types automatically**
- **Add food limits for hobo foods (#563)**
- **v0.8.20**
- **update `parseItemSkillNames` to match kolmafia r27778's new syntax**
- **v0.8.21**
- **export banish functions too**
- **v0.8.22**
- **Update property types automatically**
- **refactor `AscendError`, move causebuilding logic to  `ascend`**
- **use nullish coalescence instead of ternary**
- **first pass at monster-scraping functions**
- **upgrade eslint & eslint-plugin-libram**
- **use a `Set` for disabled**
- **add a `differentiate` function**
- **track eggs for `canReceive`**
- **v0.8.23**
- **Update property types automatically**
- **fix combat flag setter**
- **v0.8.24**
- **feat: improve lookup results for players that don't exist**
- **remove circular import from chest mimic code**
- **fix some chest mimic logic errors**
- **support new combat flag "boringdarts"**
- **Update property types automatically**
- **prune 0-quantity items in Session.current**
- **switch from copying the map to skipping entries**
- **add likely-redundant check to `value`**
- **move `getCampground` iteration**
- **add a comment for the `boringdarts` combat flag**
- **Update property types automatically**
- **Update property types automatically**
- **basic support**
- **whoops**
- **v0.8.25**
- **create & export a `haveIntrinsic` function for Effects**
- **Can't use 'instanceof' on a non-object.**
- **fix offsets, names**
- **v0.8.26**
- **upgrade mafia**
- **refine april code; add `canPlay` function**
- **remove redundant type assertions from `template-string` :)**
- **v0.8.27**
- **Additional mimic check**
- **have_**
- **Better page to check**
- **Comment change**
- **Default to 1 in case page doesn't display (1)**
- **Number is optional**
- **Requested Bill updates**
- **Add requested warning**
- **update jsdoc for `ascend.ts` to remove references to archaic path code**
- **set and use `exactOptionalPropertyTypes`**
- **chore: update to yarn 4**
- **ci: update github actions versions**
- **test: fix and extend kolmafia mock**
- **feat(Kmail): improve message parts parsing**
- **chore(Kmail): use azunixtime for parsing the message date**
- **feat(Kmail): decode entites in message text**
- **add spring boots to free run sources**
- **update kolmafia; fix crystal ball `parsedProp`**
- **Update src/diet/index.ts**
- **`yarn format`**
- **revert streamlining**
- **Case sensitivity training**
- **v0.8.28**
- **fix publish workflow**
- **allow manual publishing**
- **chore: update to jest 29**
- **ci: run tests on ci/cd**
- **fix: fix publish workflow with yarn 4**
- **test: make Kmail date test system timezone independant**
- **Run build on prepack, since yarn no longer calls prepublishOnly**
- **v0.8.29**
- **pass args to `runCombat` everywhere**
- **update/refine typing**
- **create wrapper function**
- **remove `runCombatSpread`**
- **fix imported `clamp`**
- **Update property types automatically**
- **Fix overly restrictive truthiness detection in MenuItem**
- **Bump to v0.8.30**
- **whoops**
- **v0.8.31**
- **use monsterid until there's mafia support**
- **whoops!**
- **v0.8.32**
- **update `differentiableQuantity` regex; update failure behavior; remove now-unnecessary warning**
- **just use whitespace literals**
- **work for werebear specifically**
- **fix imports**
- **v0.8.33**
- **chore: update esbuild to 0.20.2**
- **chore: add missing lodash dependency**
- **chore: update ts-node**
- **chore: switch tools to @tsconfig/node20 (which is LTS)**
- **chore: switch to ESM and set module type in package.json**
- **upgrade eslint-plugin-libram**
- **first functions, no resonances**
- **more functions and exports**
- **`resonanceAvailable`**
- **export the module**
- **adjust middle overload of `available`'s jsdoc**
- **`getResonanceResult` per Shiver**
- **Boop**
- **Oh like this**
- **eslint-plugin-libram to 0.5.7**
- **remove unnecessary `as const`**
- **Update all dependencies**
- **Fix outdated TS, allow sum to accept readonly arrays**
- **Downgrade eslint and run linting**
- **v0.8.34**
- **fix `everythingLooksGreen` action sources**
- **`yarn format`**
- **allow alternate `source` parameter for `makeByXFunction`**
- **v0.8.35**
- **BALLS improvements**
- **v0.8.36**
- **unit tests for Macro (#617)**
- **Update import style to match NodeNext for ESM**
- **Fix tests in ESM environment**
- **Completely overhaul tests**
- **Include DOM library becuase of a vitest bug (https://github.com/vitejs/vite/issues/9813). Subscribed and will remove when they fix**
- **Actually skipping libs makes way more sense in libram. Take that, libs**
- **Remove unused vi**
- **Format and restyle some code**
- **Update property types automatically**
- **Create & export some MayamCalendar utility functions for handling types**
- **v0.8.37**
- **Let's try this again, with a better lock file**
- **Bump dependencies including java-parser, patch the incorrectly specified TS types**
- **Extract new modifier types**
- **Correct lint-staged command**
- **Reflect loss of modifier types in modifiers.ts**
- **Now have to manually cast some modifier retrievals**
- **Update property types automatically**
- **Update package.json**
- **Update property types automatically**
- **Add Mini Kiwi to Thrones**
- **v0.9.1**
- **Update property types automatically**
- **Update CrownOfThrones.ts**
- **v0.9.2**
- **Fix get macro id**
- **Check specific reason for macro creation failure**
