### PR TITLE
deprecate `flat` utility function; use `flat` method in its stead

### DIFF
--- a/src/actions/ActionSource.ts
+++ b/src/actions/ActionSource.ts
@@ -2,7 +2,7 @@ import { Familiar, Item, mallPrice, Skill, useFamiliar } from "kolmafia";
 
 import { Macro } from "../combat.js";
 import { Requirement } from "../maximize.js";
-import { sum, flat } from "../utils.js";
+import { sum } from "../utils.js";
 
 export type FindActionSourceConstraints = {
   /**
@@ -187,7 +187,7 @@ export class ActionSource {
       return null;
     }
     return new ActionSource(
-      [...flat(actions.map((action) => action.source))],
+      actions.flatMap((action) => action.source),
       () => sum(actions, (action) => action.potential()),
       Macro.step(...actions.map((action) => action.macro)),
       constraints,

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -863,8 +863,7 @@ export const holidayWanderers = new Map<string, Monster[]>([
 export function getTodaysHolidayWanderers(): Monster[] {
   return holiday()
     .split("/")
-    .map((holiday) => holidayWanderers.get(holiday) ?? [])
-    .flat();
+    .flatMap((holiday) => holidayWanderers.get(holiday) ?? []);
 }
 
 /**

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1220,12 +1220,10 @@ export function setCombatFlags(
   return visitUrl(
     `account.php?${
       ([
-        flags
-          .map(({ flag, value }) => [
-            `actions[]=flag_${flag}`,
-            `flag_${flag}=${Number(value)}`,
-          ])
-          .flat(),
+        ...flags.flatMap(({ flag, value }) => [
+          `actions[]=flag_${flag}`,
+          `flag_${flag}=${Number(value)}`,
+        ]),
         "action=Update",
         "am=1",
         "ajax=1",

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -72,7 +72,7 @@ import {
   $skill,
   $stat,
 } from "./template-string.js";
-import { makeByXFunction, chunk, flat, notNull } from "./utils.js";
+import { makeByXFunction, chunk, notNull } from "./utils.js";
 
 /**
  * Determines the current maximum Accordion Thief songs the player can have in their head
@@ -861,11 +861,10 @@ export const holidayWanderers = new Map<string, Monster[]>([
  * @returns List of holiday wanderer Monsters
  */
 export function getTodaysHolidayWanderers(): Monster[] {
-  return flat(
-    holiday()
-      .split("/")
-      .map((holiday) => holidayWanderers.get(holiday) ?? []),
-  );
+  return holiday()
+    .split("/")
+    .map((holiday) => holidayWanderers.get(holiday) ?? [])
+    .flat();
 }
 
 /**
@@ -1221,12 +1220,12 @@ export function setCombatFlags(
   return visitUrl(
     `account.php?${
       ([
-        ...flat(
-          flags.map(({ flag, value }) => [
+        flags
+          .map(({ flag, value }) => [
             `actions[]=flag_${flag}`,
             `flag_${flag}=${Number(value)}`,
-          ]),
-        ),
+          ])
+          .flat(),
         "action=Update",
         "am=1",
         "ajax=1",

--- a/src/resources/2023/CursedMonkeyPaw.ts
+++ b/src/resources/2023/CursedMonkeyPaw.ts
@@ -50,10 +50,10 @@ export function wishableItems(filters: WishableItemsFilters = {}): Set<Item> {
   return new Set(
     Location.all()
       .filter((l) => canAdventure(l) && (filters.location?.(l) ?? true))
-      .map((l) =>
+      .flatMap((l) =>
         getMonsters(l)
           .filter((m) => m.copyable && (filters.monster?.(m) ?? true))
-          .map((m) =>
+          .flatMap((m) =>
             itemDropsArray(m)
               .filter(
                 ({ type, rate, drop }) =>
@@ -63,8 +63,7 @@ export function wishableItems(filters: WishableItemsFilters = {}): Set<Item> {
               )
               .map(({ drop }) => drop),
           ),
-      )
-      .flat(2),
+      ),
   );
 }
 

--- a/src/resources/2023/CursedMonkeyPaw.ts
+++ b/src/resources/2023/CursedMonkeyPaw.ts
@@ -15,7 +15,7 @@ import { have as have_ } from "../../lib.js";
 import logger from "../../logger.js";
 import { get } from "../../property.js";
 import { $item } from "../../template-string.js";
-import { clamp, flat } from "../../utils.js";
+import { clamp } from "../../utils.js";
 
 const item = $item`cursed monkey's paw`;
 
@@ -48,24 +48,23 @@ export type WishableItemsFilters = Partial<{
  */
 export function wishableItems(filters: WishableItemsFilters = {}): Set<Item> {
   return new Set(
-    flat<Item[][][], 3>(
-      Location.all()
-        .filter((l) => canAdventure(l) && (filters.location?.(l) ?? true))
-        .map((l) =>
-          getMonsters(l)
-            .filter((m) => m.copyable && (filters.monster?.(m) ?? true))
-            .map((m) =>
-              itemDropsArray(m)
-                .filter(
-                  ({ type, rate, drop }) =>
-                    !drop.quest &&
-                    (type !== "c" || rate >= 1) && // Remove random roll drops
-                    (filters.drop?.({ type, rate, drop }) ?? true),
-                )
-                .map(({ drop }) => drop),
-            ),
-        ),
-    ),
+    Location.all()
+      .filter((l) => canAdventure(l) && (filters.location?.(l) ?? true))
+      .map((l) =>
+        getMonsters(l)
+          .filter((m) => m.copyable && (filters.monster?.(m) ?? true))
+          .map((m) =>
+            itemDropsArray(m)
+              .filter(
+                ({ type, rate, drop }) =>
+                  !drop.quest &&
+                  (type !== "c" || rate >= 1) && // Remove random roll drops
+                  (filters.drop?.({ type, rate, drop }) ?? true),
+              )
+              .map(({ drop }) => drop),
+          ),
+      )
+      .flat(2),
   );
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -357,6 +357,7 @@ export function makeByXFunction<T extends string>(
 
 /**
  * Flattens an array. Basically replacing Array.prototype.flat for which Rhino doesn't yet have an implementation
+ * @deprecated KoLMafia now supports the `flat` and `flatMap` methods
  *
  * @param arr Array to flatten
  * @param depth Number of layers to flatten by; Infinity for a fully flat array


### PR DESCRIPTION
Gausie, I know you have some code for polyfilling `matchAll`, and we can remove that too I think. Right, @migleyc? 