### PR TITLE
fix: don't check value before setting it

### DIFF
--- a/src/property.ts
+++ b/src/property.ts
@@ -451,7 +451,7 @@ export class PropertiesManager {
       const value = this.properties[property];
       if (value === PropertiesManager.EMPTY_PREFERENCE) {
         removeProperty(property);
-      } else if (value) {
+      } else {
         set(property, value as { toString(): string });
       }
     }


### PR DESCRIPTION
This is necessary to correctly reset preferences that were `false`.