### PR TITLE
chore: fix circular imports

### DIFF
--- a/src/resources/2006/CommaChameleon.ts
+++ b/src/resources/2006/CommaChameleon.ts
@@ -1,7 +1,7 @@
 import { $familiar, $item } from "../../template-string.js";
 import { have as have_ } from "../../lib.js";
 import { Familiar, familiarEquipment, toInt, visitUrl } from "kolmafia";
-import { get } from "../../index.js";
+import { get } from "../../property.js";
 
 const familiar = $familiar`Comma Chameleon`;
 


### PR DESCRIPTION
...by not importing from barrel file.

Otherwise, consuming libram with rollup yields the following warning:

```
(!) Circular dependency
../node_modules/libram/dist/index.js -> ../node_modules/libram/dist/ascend.js -> ../node_modules/libram/dist/resources/index.js -> ../node_modules/libram/dist/resources/2006/CommaChameleon.js -> ../node_modules/libram/dist/index.js
```