### PR TITLE
ChestMimic xpath query needs parens

### DIFF
--- a/src/resources/2024/ChestMimic.ts
+++ b/src/resources/2024/ChestMimic.ts
@@ -46,14 +46,16 @@ const canReceive = () =>
   familiar.experience >= 100 && get("_mimicEggsObtained") < 11;
 
 const makeXpath = (selectNumber: number, disabled: boolean): string =>
-  `(//select[@name="mid"])[${selectNumber}]/option[position()>0]${
+  `(//select[@name="mid"])[${selectNumber}]/option${
     disabled ? "[@disabled]" : ""
   }/@value`;
 
 function getMonsters(selectNumber: number, page: string): Monster[] {
   const total = xpath(page, makeXpath(selectNumber, false));
   const disabled = new Set(xpath(page, makeXpath(selectNumber, true)));
-  return total.filter((m) => !disabled.has(m)).map((id) => toMonster(id));
+  return total
+    .filter((m) => m != "" && !disabled.has(m))
+    .map((id) => toMonster(id));
 }
 
 /**


### PR DESCRIPTION
Without these parens ChestMimic.getDonableMonsters() was returning an empty list

```
> jsl ChestMimic.getDonableMonsters()

Returned: aggregate monster [2]
0 => none
1 => Weapons-Assembly Elfborg

> jsl ChestMimic.donate($monster`Weapons-Assembly Elfborg`)

Submitting option 1 for choice 1517
Preference mimicEggMonsters changed from 439:3 to 439:2
Preference _mimicEggsDonated changed from 0 to 1
Returned: true

> jsl ChestMimic.donate($monster`Weapons-Assembly Elfborg`)

Submitting option 1 for choice 1517
Preference mimicEggMonsters changed from 439:2 to 439:1
Preference _mimicEggsDonated changed from 1 to 2
Returned: true

> jsl ChestMimic.donate($monster`Weapons-Assembly Elfborg`)

Submitting option 1 for choice 1517
Preference mimicEggMonsters changed from 439:1 to
Preference _mimicEggsDonated changed from 2 to 3
Returned: true

> jsl ChestMimic.getDonableMonsters()

Returned: aggregate null [0]
```