### PR TITLE
Macro support funksling list of items

### DIFF
--- a/src/Macro.test.ts
+++ b/src/Macro.test.ts
@@ -114,10 +114,121 @@ describe(Macro, () => {
     expect(Macro.item(mock).toString()).toEqual(`use ${mock.name};`);
   });
 
+  it("item pair", () => {
+    const mock = $item`mock item`;
+    expect(Macro.item([mock, mock]).toString()).toEqual(
+      `use ${mock.name}, ${mock.name};`,
+    );
+  });
+
+  it("item pair + single", () => {
+    const mock = $item`mock item`;
+    expect(Macro.item([mock, mock], mock).toString()).toEqual(
+      `${Macro.item([mock, mock]).toString()}${Macro.item(mock).toString()}`,
+    );
+  });
+
+  it("item pair + pair", () => {
+    const mock = $item`mock item`;
+    expect(Macro.item([mock, mock], [mock, mock]).toString()).toEqual(
+      `use ${mock.name}, ${mock.name};use ${mock.name}, ${mock.name};`,
+    );
+  });
+
   it("tryItem", () => {
     const mock = $item`mock item`;
     expect(Macro.tryItem(mock).toString()).toEqual(
       `if hascombatitem mock item;use ${mock.name};endif;`,
+    );
+  });
+
+  it("tryItem same pair", () => {
+    const mock = $item`mock item`;
+    expect(Macro.tryItem([mock, mock]).toString()).toEqual(
+      `if hastwocombatitems mock item;use mock item, mock item;endif;`,
+    );
+  });
+
+  it("tryItem different pair", () => {
+    const mock1 = $item`mock item`;
+    const mock2 = $item`mock item two`;
+    expect(Macro.tryItem([mock1, mock2]).toString()).toEqual(
+      `if hascombatitem mock item && hascombatitem mock item two;use mock item, mock item two;endif;`,
+    );
+  });
+
+  it("tryItem same pair + single", () => {
+    const mock = $item`mock item`;
+    expect(Macro.tryItem([mock, mock], mock).toString()).toEqual(
+      `${Macro.tryItem([mock, mock]).toString()}${Macro.tryItem(mock).toString()}`,
+    );
+  });
+
+  it("tryItem different pair + single", () => {
+    const mock1 = $item`mock item`;
+    const mock2 = $item`mock item two`;
+    expect(Macro.tryItem([mock1, mock2], mock1).toString()).toEqual(
+      `${Macro.tryItem([mock1, mock2]).toString()}${Macro.tryItem(mock1).toString()}`,
+    );
+  });
+
+  it("funkslingItem same items", () => {
+    const mock = $item`mock item`;
+    expect(Macro.funkslingItem(mock, mock).toString()).toEqual(
+      Macro.item([mock, mock]).toString(),
+    );
+  });
+
+  it("funkslingItem different items", () => {
+    const mock1 = $item`mock item`;
+    const mock2 = $item`mock item two`;
+    expect(Macro.funkslingItem(mock1, mock2).toString()).toEqual(
+      Macro.item([mock1, mock2]).toString(),
+    );
+  });
+
+  it("funklingItem same pair + single", () => {
+    const mock = $item`mock item`;
+    expect(Macro.funkslingItem(mock, mock, mock).toString()).toEqual(
+      Macro.item([mock, mock], mock).toString(),
+    );
+  });
+
+  it("funklingItem different pair + single", () => {
+    const mock1 = $item`mock item`;
+    const mock2 = $item`mock item two`;
+    expect(Macro.funkslingItem(mock1, mock2, mock1).toString()).toEqual(
+      Macro.item([mock1, mock2], mock1).toString(),
+    );
+  });
+
+  it("tryFunklingItem same", () => {
+    const mock = $item`mock item`;
+    expect(Macro.tryFunkslingItem(mock, mock).toString()).toEqual(
+      Macro.tryItem([mock, mock]).toString(),
+    );
+  });
+
+  it("tryFunklingItem different", () => {
+    const mock1 = $item`mock item`;
+    const mock2 = $item`mock item two`;
+    expect(Macro.tryFunkslingItem(mock1, mock2).toString()).toEqual(
+      Macro.tryItem([mock1, mock2]).toString(),
+    );
+  });
+
+  it("tryFunklingItem same pair + single", () => {
+    const mock = $item`mock item`;
+    expect(Macro.tryFunkslingItem(mock, mock, mock).toString()).toEqual(
+      Macro.tryItem([mock, mock], mock).toString(),
+    );
+  });
+
+  it("tryFunklingItem different pair + single", () => {
+    const mock1 = $item`mock item`;
+    const mock2 = $item`mock item two`;
+    expect(Macro.tryFunkslingItem(mock1, mock2, mock1).toString()).toEqual(
+      Macro.tryItem([mock1, mock2], mock1).toString(),
     );
   });
 
@@ -162,6 +273,21 @@ describe(Macro.makeBALLSPredicate, () => {
     const mock = $item`mock combat item`;
     expect(Macro.makeBALLSPredicate(mock)).toEqual(
       `hascombatitem ${mock.name}`,
+    );
+  });
+
+  it("Item Pair Same", () => {
+    const mock = $item`mock combat item`;
+    expect(Macro.makeBALLSPredicate([mock, mock])).toEqual(
+      `hastwocombatitems ${mock.name}`,
+    );
+  });
+
+  it("Item Pair Different", () => {
+    const mock1 = $item`mock combat item`;
+    const mock2 = $item`mock combat item two`;
+    expect(Macro.makeBALLSPredicate([mock1, mock2])).toEqual(
+      `hascombatitem ${mock1.name} && hascombatitem ${mock2.name}`,
     );
   });
 

--- a/src/combat.ts
+++ b/src/combat.ts
@@ -159,6 +159,28 @@ function skillBallsMacroName(skillOrName: SkillOrName) {
     : skill.id;
 }
 
+/**
+ * Reduces a list of items into pairs to funksling.
+ *
+ * @param items - The items to be reduced.
+ * @returns The reduced list of items or item pairs.
+ */
+function funkslingReduce(
+  ...items: ItemOrName[]
+): (ItemOrName | [ItemOrName, ItemOrName])[] {
+  return items.reduce<(ItemOrName | [ItemOrName, ItemOrName])[]>(
+    (acc, item, i, arr) =>
+      i % 2 === 0
+        ? acc.concat(
+            i + 1 < arr.length
+              ? [[item, arr[i + 1]] as [ItemOrName, ItemOrName]]
+              : [item],
+          )
+        : acc,
+    [],
+  );
+}
+
 type Constructor<T> = { new (): T };
 
 export class InvalidMacroError extends Error {}
@@ -716,6 +738,58 @@ export class Macro {
   }
 
   /**
+   * Add one or more item steps to the macro, and automatically attempting to funksling as many of the items as possible.
+   * This function does not check if you can funksling or not.
+   *
+   * @param items Items to use.
+   * @returns {Macro} This object itself.
+   */
+  funkslingItem(...items: ItemOrName[]): this {
+    return this.item(...funkslingReduce(...items));
+  }
+
+  /**
+   * Create a new macro with one or more item steps, and automatically attempting to funksling as many of the items as possible.
+   * This function does not check if you can funksling or not.
+   *
+   * @param items Items to use.
+   * @returns {Macro} This object itself.
+   */
+  static funkslingItem<T extends Macro>(
+    this: Constructor<T>,
+    ...items: ItemOrName[]
+  ): T {
+    return new this().funkslingItem(...items);
+  }
+
+  /**
+   * Add one or more item steps to the macro, where each step checks to see if you have the item first,
+   * and automatically attempting to funksling as many of the items as possible.
+   * This function does not check if you can funksling or not.
+   *
+   * @param items Items to use.
+   * @returns {Macro} This object itself.
+   */
+  tryFunkslingItem(...items: ItemOrName[]): this {
+    return this.tryItem(...funkslingReduce(...items));
+  }
+
+  /**
+   * Create a new macro with one or more item steps, where each step checks to see if you have the item first,
+   * and automatically attempting to funksling as many of the items as possible.
+   * This function does not check if you can funksling or not.
+   *
+   * @param items Items to use.
+   * @returns {Macro} This object itself.
+   */
+  static tryFunkslingItem<T extends Macro>(
+    this: Constructor<T>,
+    ...items: ItemOrName[]
+  ): T {
+    return new this().tryFunkslingItem(...items);
+  }
+
+  /**
    * Add an attack step to the macro.
    *
    * @returns {Macro} This object itself.
@@ -927,6 +1001,58 @@ export class StrictMacro extends Macro {
     ...items: (Item | [Item, Item])[]
   ): T {
     return new this().tryItem(...items);
+  }
+
+  /**
+   * Add one or more item steps to the macro, and automatically attempting to funksling as many of the items as possible.
+   * This function does not check if you can funksling or not.
+   *
+   * @param items Items to use.
+   * @returns {StrictMacro} This object itself.
+   */
+  funkslingItem(...items: Item[]): this {
+    return super.funkslingItem(...items);
+  }
+
+  /**
+   * Create a new macro with one or more item steps, and automatically attempting to funksling as many of the items as possible.
+   * This function does not check if you can funksling or not.
+   *
+   * @param items Items to use.
+   * @returns {StrictMacro} This object itself.
+   */
+  static funkslingItem<T extends StrictMacro>(
+    this: Constructor<T>,
+    ...items: Item[]
+  ): T {
+    return new this().funkslingItem(...items);
+  }
+
+  /**
+   * Add one or more item steps to the macro, where each step checks to see if you have the item first,
+   * and automatically attempting to funksling as many of the items as possible.
+   * This function does not check if you can funksling or not.
+   *
+   * @param items Items to use.
+   * @returns {StrictMacro} This object itself.
+   */
+  tryFunkslingItem(...items: Item[]): this {
+    return super.tryFunkslingItem(...items);
+  }
+
+  /**
+   * Create a new macro with one or more item steps, where each step checks to see if you have the item first,
+   * and automatically attempting to funksling as many of the items as possible.
+   * This function does not check if you can funksling or not.
+   *
+   * @param items Items to use.
+   * @returns {StrictMacro} This object itself.
+   */
+  static tryFunkslingItem<T extends StrictMacro>(
+    this: Constructor<T>,
+    ...items: Item[]
+  ): T {
+    return new this().tryFunkslingItem(...items);
   }
 
   /**


### PR DESCRIPTION
Add functions to automatically reduce a list of items to a list of pairs to be funkslinged, with any remaining item being used by itself.

These functions, like item() or tryItem() do not check if you can funksling.

Just as with tryItem() if a pair of items is to be used, you need to have both or neither will be used. To ensure all items are used you will want to filter the array of items by what you have.