### PR TITLE
chore: fix circular imports

### DIFF
--- a/src/resources/2025/CyberRealm.ts
+++ b/src/resources/2025/CyberRealm.ts
@@ -1,6 +1,7 @@
 import { gamedayToInt, Item } from "kolmafia";
 import { realmAvailable } from "../../lib.js";
-import { $item, get } from "../../index.js";
+import { get } from "../../property.js";
+import { $item } from "../../template-string.js";
 
 /**
  * @returns Whether or not you have Cyber Realm


### PR DESCRIPTION
...by not importing from barrel file

Otherwise consuming libram with rollup fails with:

```
(!) Circular dependency
../node_modules/libram/dist/index.js -> ../node_modules/libram/dist/ascend.js -> ../node_modules/libram/dist/resources/index.js -> ../node_modules/libram/dist/resources/2025/CyberRealm.js -> ../node_modules/libram/dist/index.js
```

This [has](https://github.com/loathers/libram/pull/114) [happened](https://github.com/loathers/libram/pull/543) [a lot](https://github.com/loathers/libram/pull/578) [in the](https://github.com/loathers/libram/pull/741) [past](https://github.com/loathers/libram/pull/64). Can we add some linter rule or similar to prevent this going forward?