### PR TITLE
Sort item entries in session JSON

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -315,10 +315,12 @@ export class Session {
   toFile(filename: string): void {
     const val = {
       meat: this.meat,
-      items: Object.fromEntries(this.items),
+      items: Object.fromEntries(
+        [...this.items.entries()].sort(([a], [b]) => a.id - b.id),
+      ),
       totalTurns: this.totalTurns,
     };
-    bufferToFile(JSON.stringify(val), Session.getFilepath(filename));
+    bufferToFile(JSON.stringify(val, null, 2), Session.getFilepath(filename));
   }
 
   /**


### PR DESCRIPTION
Additionally make document readable rather than a compact single line, since we're not dealing with super massive datasets that need to save a lot of binary size this will be easier for a human to read.