### PR TITLE
Name the clan that player's are not whitelisted to

### DIFF
--- a/src/Clan.ts
+++ b/src/Clan.ts
@@ -123,7 +123,7 @@ export class Clan {
         );
 
         if (!clan) {
-          throw new Error("Player is not whitelisted to clan");
+          throw new Error(`Player is not whitelisted to clan '${clanIdOrName}'`);
         }
 
         clanIdCache[clanName] = clan.id;

--- a/src/Clan.ts
+++ b/src/Clan.ts
@@ -123,9 +123,9 @@ export class Clan {
         );
 
         if (!clan) {
-          throw new Error(`Player is not whitelisted to clan '${
-            clanIdOrName
-          }'`);
+          throw new Error(
+            `Player is not whitelisted to clan '${clanIdOrName}'`,
+          );
         }
 
         clanIdCache[clanName] = clan.id;

--- a/src/Clan.ts
+++ b/src/Clan.ts
@@ -123,7 +123,9 @@ export class Clan {
         );
 
         if (!clan) {
-          throw new Error(`Player is not whitelisted to clan '${clanIdOrName}'`);
+          throw new Error(`Player is not whitelisted to clan '${
+            clanIdOrName
+          }'`);
         }
 
         clanIdCache[clanName] = clan.id;


### PR DESCRIPTION
Naming the clan in the error would reduce the number of reports being made, and make it easier to debug where the issue is. This isn't the first time I wished it named the clan while helping a user figure out why a script broke.