### PR TITLE
Add 'walfordBucketItem' to fake item list

### DIFF
--- a/tools/parseDefaultProperties.ts
+++ b/tools/parseDefaultProperties.ts
@@ -118,7 +118,7 @@ const fakeItemProps = [
   "currentEasyBountyItem",
   "currentHardBountyItem",
   "currentSpecialBountyItem",
-  "walfordBucketItem"
+  "walfordBucketItem",
 ];
 const itemProps = [
   "trapperOre",

--- a/tools/parseDefaultProperties.ts
+++ b/tools/parseDefaultProperties.ts
@@ -118,6 +118,7 @@ const fakeItemProps = [
   "currentEasyBountyItem",
   "currentHardBountyItem",
   "currentSpecialBountyItem",
+  "walfordBucketItem"
 ];
 const itemProps = [
   "trapperOre",


### PR DESCRIPTION
Kolmafia populates the property with a list of non-items, like "rain" and "ice".
This PR should prevent that property being added as an ItemProperty