### PR TITLE
Run pinst before publish instead of from prepack

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,4 +18,5 @@ jobs:
           registry-url: "https://registry.npmjs.org"
       - run: yarn install --immutable
       - run: npm install -g npm@latest
+      - run: yarn pinst --disable
       - run: npm publish

--- a/package.json
+++ b/package.json
@@ -17,12 +17,11 @@
     "format": "yarn run prettier --write . && yarn run eslint --fix .",
     "lint": "yarn run eslint && yarn run prettier --check .",
     "test": "yarn run vitest",
-    "prepack": "yarn run build && pinst --disable",
+    "prepack": "yarn run build",
     "updateProps": "node --import tsx ./tools/parseDefaultProperties.ts",
     "updateOverlappingItemSkillNames": "node --import tsx ./tools/parseItemSkillNames.ts",
     "parseModifiers": "node --import tsx ./tools/parseModifiers.ts",
-    "postinstall": "husky install",
-    "postpack": "pinst --enable"
+    "postinstall": "husky install"
   },
   "files": [
     "dist/**/*.js",


### PR DESCRIPTION
`npm install libram` fails with `sh: husky: command not found` (exit 127) on every release since 0.11.12. yarn and pnpm are unaffected.

`pinst --disable` in `prepack` only cleans the tarball. `npm publish` rebuilds the registry manifest from `package.json` *after* `postpack` runs `pinst --enable`, so the published metadata keeps `postinstall` — and npm >=10.4 reads install scripts from that metadata rather than from the tarball.

Known upstream problem; the documented fix is to run pinst around the publish command rather than from the pack lifecycle:

- https://github.com/typicode/pinst/pull/24
- https://gist.github.com/djcsdy/3ca078e23fdac4c50e077c84e8284a95

We were insulated from it until 8c18cdce switched `yarn npm publish` (which builds the registry body inside the pack step) to `npm publish` for OIDC.

Verified against a local registry with the real package: registry metadata now matches the tarball, and `npm install libram` succeeds. Contributors are unaffected — `postinstall` is unchanged and `yarn install` still sets up hooks.

Needs a release to reach consumers; 0.11.12–0.11.23 stay broken.
