### PR TITLE
support long else...if blocks?

### DIFF
--- a/src/combat.ts
+++ b/src/combat.ts
@@ -578,7 +578,9 @@ export class Macro {
         this.step("else").step(elseEntry);
       }
     }
-    this.step(elseTrain.filter(Boolean).length ? "endelse" : "endif");
+
+    this.step("endif");
+
     return this;
   }
 

--- a/src/combat.ts
+++ b/src/combat.ts
@@ -563,7 +563,7 @@ export class Macro {
   if_(
     condition: PreBALLSPredicate,
     ifTrue: string | Macro,
-    ...elseTrain: ElseTrain<Macro>
+    ...elseTrain: ElseTrain
   ): this {
     this.step(`if ${Macro.makeBALLSPredicate(condition)}`).step(ifTrue);
 
@@ -575,7 +575,7 @@ export class Macro {
         this.step("else").step(elseEntry);
       }
     }
-    if (elseTrain.length) this.step("endelse");
+    this.step(elseTrain.length ? "endelse" : "endif");
     return this;
   }
 

--- a/src/combat.ts
+++ b/src/combat.ts
@@ -185,6 +185,14 @@ type Constructor<T> = { new (): T };
 
 export class InvalidMacroError extends Error {}
 
+export type ElseIfComponent = {
+  predicate: PreBALLSPredicate;
+  macro: string | Macro;
+};
+export type ElseTrain =
+  | ElseIfComponent[]
+  | [...ElseIfComponent[], string | Macro];
+
 /**
  * BALLS macro builder for direct submission to KoL.
  * Create a new macro with `new Macro()` and add steps using the instance methods.
@@ -469,22 +477,25 @@ export class Macro {
    *
    * @param condition The BALLS condition for the if statement.
    * @param ifTrue Continuation if the condition is true.
-   * @param ifFalse Optional else-branch for the macro
+   * @param elseTrain Spread array of { predicate, macro } elif entries, followed by an final bare string/Macro for the final Else
    * @returns {Macro} This object itself.
    */
   if_(
     condition: PreBALLSPredicate,
     ifTrue: string | Macro,
-    ifFalse?: string | Macro,
+    ...elseTrain: ElseTrain<Macro>
   ): this {
     this.step(`if ${Macro.makeBALLSPredicate(condition)}`).step(ifTrue);
 
-    if (ifFalse) {
-      this.step("else").step(ifFalse).step("endelf");
-    } else {
-      this.step("endif");
+    for (const elseEntry of elseTrain) {
+      if (typeof elseEntry === "object" && !(elseEntry instanceof Macro)) {
+        const { predicate, macro } = elseEntry;
+        this.step(`elif ${Macro.makeBALLSPredicate(predicate)}`).step(macro);
+      } else {
+        this.step("else").step(elseEntry);
+      }
     }
-
+    if (elseTrain.length) this.step("endelse");
     return this;
   }
 
@@ -493,16 +504,16 @@ export class Macro {
    *
    * @param condition The BALLS condition for the if statement.
    * @param ifTrue Continuation if the condition is true.
-   * @param ifFalse Optional else-branch for the macro
+   * @param elseTrain Spread array of { predicate, macro } elif entries, followed by an final bare string/Macro for the final Else
    * @returns {Macro} This object itself.
    */
   static if_<T extends Macro>(
     this: Constructor<T>,
     condition: PreBALLSPredicate,
     ifTrue: string | Macro,
-    ifFalse?: string | Macro,
+    ...elseTrain: ElseTrain
   ): T {
-    return new this().if_(condition, ifTrue, ifFalse);
+    return new this().if_(condition, ifTrue, ...elseTrain);
   }
 
   /**

--- a/src/combat.ts
+++ b/src/combat.ts
@@ -191,7 +191,7 @@ export type ElseIfComponent = {
 };
 export type ElseTrain =
   | ElseIfComponent[]
-  | [...ElseIfComponent[], string | Macro];
+  | [...ElseIfComponent[], undefined | string | Macro];
 
 /**
  * BALLS macro builder for direct submission to KoL.
@@ -567,7 +567,7 @@ export class Macro {
   ): this {
     this.step(`if ${Macro.makeBALLSPredicate(condition)}`).step(ifTrue);
 
-    for (const elseEntry of elseTrain) {
+    for (const elseEntry of elseTrain.filter(Boolean)) {
       if (typeof elseEntry === "object" && !(elseEntry instanceof Macro)) {
         const { predicate, macro } = elseEntry;
         this.step(`elif ${Macro.makeBALLSPredicate(predicate)}`).step(macro);
@@ -575,7 +575,7 @@ export class Macro {
         this.step("else").step(elseEntry);
       }
     }
-    this.step(elseTrain.length ? "endelse" : "endif");
+    this.step(elseTrain.filter(Boolean).length ? "endelse" : "endif");
     return this;
   }
 

--- a/src/combat.ts
+++ b/src/combat.ts
@@ -25,6 +25,7 @@ import {
   overlappingSkillNames,
 } from "./overlappingNames.js";
 import { get, set } from "./property.js";
+import { notNullish } from "./utils.js";
 
 const MACRO_NAME = "Script Autoattack Macro";
 /**
@@ -567,7 +568,9 @@ export class Macro {
   ): this {
     this.step(`if ${Macro.makeBALLSPredicate(condition)}`).step(ifTrue);
 
-    for (const elseEntry of elseTrain.filter(Boolean)) {
+    for (const elseEntry of (elseTrain as ElseTrain[number][]).filter(
+      notNullish,
+    )) {
       if (typeof elseEntry === "object" && !(elseEntry instanceof Macro)) {
         const { predicate, macro } = elseEntry;
         this.step(`elif ${Macro.makeBALLSPredicate(predicate)}`).step(macro);

--- a/src/combat.ts
+++ b/src/combat.ts
@@ -469,12 +469,23 @@ export class Macro {
    *
    * @param condition The BALLS condition for the if statement.
    * @param ifTrue Continuation if the condition is true.
+   * @param ifFalse Optional else-branch for the macro
    * @returns {Macro} This object itself.
    */
-  if_(condition: PreBALLSPredicate, ifTrue: string | Macro): this {
-    return this.step(`if ${Macro.makeBALLSPredicate(condition)}`)
-      .step(ifTrue)
-      .step("endif");
+  if_(
+    condition: PreBALLSPredicate,
+    ifTrue: string | Macro,
+    ifFalse?: string | Macro,
+  ): this {
+    this.step(`if ${Macro.makeBALLSPredicate(condition)}`).step(ifTrue);
+
+    if (ifFalse) {
+      this.step("else").step(ifFalse).step("endelf");
+    } else {
+      this.step("endif");
+    }
+
+    return this;
   }
 
   /**
@@ -482,39 +493,48 @@ export class Macro {
    *
    * @param condition The BALLS condition for the if statement.
    * @param ifTrue Continuation if the condition is true.
+   * @param ifFalse Optional else-branch for the macro
    * @returns {Macro} This object itself.
    */
   static if_<T extends Macro>(
     this: Constructor<T>,
     condition: PreBALLSPredicate,
     ifTrue: string | Macro,
+    ifFalse?: string | Macro,
   ): T {
-    return new this().if_(condition, ifTrue);
+    return new this().if_(condition, ifTrue, ifFalse);
   }
 
   /**
    * Add an "if" statement to this macro, inverting the condition.
    *
    * @param condition The BALLS condition for the if statement.
-   * @param ifTrue Continuation if the condition is true.
+   * @param ifTrue Continuation if the negated condition is true.
+   * @param ifFalse Optional else-branch for the macro
    * @returns {Macro} This object itself.
    */
-  ifNot(condition: PreBALLSPredicate, ifTrue: string | Macro): this {
-    return this.if_(`!${Macro.makeBALLSPredicate(condition)}`, ifTrue);
+  ifNot(
+    condition: PreBALLSPredicate,
+    ifTrue: string | Macro,
+    ifFalse?: string | Macro,
+  ): this {
+    return this.if_(`!${Macro.makeBALLSPredicate(condition)}`, ifTrue, ifFalse);
   }
   /**
    * Create a new macro with an "if" statement, inverting the condition.
    *
    * @param condition The BALLS condition for the if statement.
-   * @param ifTrue Continuation if the condition is true.
+   * @param ifTrue Continuation if the negated condition is true.
+   * @param ifFalse Optional else-branch for the macro
    * @returns {Macro} This object itself.
    */
   static ifNot<T extends Macro>(
     this: Constructor<T>,
     condition: PreBALLSPredicate,
     ifTrue: string | Macro,
+    ifFalse?: string | Macro,
   ): T {
-    return new this().ifNot(condition, ifTrue);
+    return new this().ifNot(condition, ifTrue, ifFalse);
   }
 
   /**

--- a/src/combat.ts
+++ b/src/combat.ts
@@ -565,12 +565,27 @@ export class Macro {
     condition: PreBALLSPredicate,
     ifTrue: string | Macro,
     ...elseTrain: ElseTrain
+  ): this;
+  /**
+   * Add an "if" statement to this macro, followed by a long chain of "elif"s, followed optionally by an "else"
+   *
+   * @param elseTrain Spread array of { predicate, macro } elif entries, followed by an final bare string/Macro for the final Else.
+   * @returns {Macro} This object itself.
+   */
+  if_(...elseTrain: ElseTrain): this;
+  if_(
+    leadingArg: PreBALLSPredicate | ElseIfComponent,
+    secondArg: typeof leadingArg extends ElseIfComponent
+      ? ElseIfComponent | undefined
+      : string | Macro,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ...rest: any[]
   ): this {
-    this.step(`if ${Macro.makeBALLSPredicate(condition)}`).step(ifTrue);
+    if (!(typeof leadingArg === "object" && "predicate" in leadingArg)) {
+      this.step(`if ${Macro.makeBALLSPredicate(leadingArg)}`, secondArg);
+    }
 
-    for (const elseEntry of (elseTrain as ElseTrain[number][]).filter(
-      notNullish,
-    )) {
+    for (const elseEntry of (rest as ElseTrain[number][]).filter(notNullish)) {
       if (typeof elseEntry === "object" && !(elseEntry instanceof Macro)) {
         const { predicate, macro } = elseEntry;
         this.step(`elif ${Macro.makeBALLSPredicate(predicate)}`).step(macro);


### PR DESCRIPTION
This essentially lets us continue to honor the contract of `if_` as it previously existed and as it existed in the first `else` work. But we don't need to honor the latter, because it hasn't been released.

I don't love that the frontmost elements don't need to be an object but subsequent entries do. Maybe it makes sense to keep `if_` as it once was, and do `ifElse` that accepts just an `ElseTrain` argument?